### PR TITLE
Delegate protocol to enable or disable the feature 

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,3 @@
+swift:
+  enabled: true
+  config_file: .swiftlint.yml

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,17 @@
+# disabled_rules: # rule identifiers to exclude from running
+  # - colon
+  # - comma
+  # - control_statement
+  # - force_cast
+  # - ...
+  # Find all the available rules by running:
+  # swiftlint rules
+included: # paths to include during linting. `--path` is ignored if present.
+  - Pod/Classes
+# parameterized rules can be customized from this configuration file
+line_length: 120
+# parameterized rules are first parameterized as a warning level, then error level.
+type_body_length:
+  - 300 # warning
+  - 400 # error
+# reporter: "csv" # reporter type (xcode, json, csv, checkstyle)

--- a/Example/BugShaker.xcodeproj/project.pbxproj
+++ b/Example/BugShaker.xcodeproj/project.pbxproj
@@ -169,6 +169,7 @@
 				607FACCE1AFB9204008FA782 /* Resources */,
 				4D8A95EA216DD9F65EB5BCBF /* Embed Pods Frameworks */,
 				0F62EA822D54CF4E4386A0B8 /* Copy Pods Resources */,
+				C5864A551C56BDF40090C6F5 /* Swiftlint */,
 			);
 			buildRules = (
 			);
@@ -332,6 +333,20 @@
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
+		};
+		C5864A551C56BDF40090C6F5 /* Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = Swiftlint;
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n  cd .. && swiftlint\nelse\n  echo \"SwiftLint does not exist, download from https://github.com/realm/SwiftLint\"\nfi";
 		};
 		CD60A218FAC9EF6D1EED2CEF /* Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Example/BugShaker/AppDelegate.swift
+++ b/Example/BugShaker/AppDelegate.swift
@@ -11,7 +11,7 @@ import UIKit
 import BugShaker
 
 @UIApplicationMain
-class AppDelegate: UIResponder, UIApplicationDelegate {
+class AppDelegate: UIResponder, UIApplicationDelegate, BugShakerDelegate {
 
   var window: UIWindow?
 
@@ -21,9 +21,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     *  and an optional custom subject line to use for all bug reports.
     */
 
-    BugShaker.configure(to: ["example@email.com"], subject: "Bug Report", body: "Hi Developers, I am reporting a bug where ... ")
+    BugShaker.configure(to: ["example@email.com"], subject: "Bug Report", body: "Hi Developers, I am reporting a bug where ... ", delegate: self)
     
     return true
   }
+
+    func shouldPresentReportPrompt() -> Bool {
+        // here you can read some settings from user defaults and decide if you want to have the bug report alert to show up or not
+        if NSUserDefaults.standardUserDefaults().stringForKey("CONFIG_ENABLE_BUGSHAKE") != "\(true)" {
+            return false
+        }
+        return true
+    }
 
 }

--- a/Example/Pods/Headers/Private/Nimble/DSL.h
+++ b/Example/Pods/Headers/Private/Nimble/DSL.h
@@ -1,1 +1,135 @@
-../../../Nimble/Nimble/objc/DSL.h
+#import <Foundation/Foundation.h>
+
+@class NMBExpectation;
+@class NMBObjCBeCloseToMatcher;
+@class NMBObjCRaiseExceptionMatcher;
+@protocol NMBMatcher;
+
+
+#define NIMBLE_EXPORT FOUNDATION_EXPORT
+
+#ifdef NIMBLE_DISABLE_SHORT_SYNTAX
+#define NIMBLE_SHORT(PROTO, ORIGINAL)
+#else
+#define NIMBLE_SHORT(PROTO, ORIGINAL) FOUNDATION_STATIC_INLINE PROTO { return (ORIGINAL); }
+#endif
+
+NIMBLE_EXPORT NMBExpectation *NMB_expect(id(^actualBlock)(), NSString *file, NSUInteger line);
+NIMBLE_EXPORT NMBExpectation *NMB_expectAction(void(^actualBlock)(), NSString *file, NSUInteger line);
+
+NIMBLE_EXPORT id<NMBMatcher> NMB_equal(id expectedValue);
+NIMBLE_SHORT(id<NMBMatcher> equal(id expectedValue),
+             NMB_equal(expectedValue));
+
+NIMBLE_EXPORT id<NMBMatcher> NMB_haveCount(id expectedValue);
+NIMBLE_SHORT(id<NMBMatcher> haveCount(id expectedValue),
+             NMB_haveCount(expectedValue));
+
+NIMBLE_EXPORT NMBObjCBeCloseToMatcher *NMB_beCloseTo(NSNumber *expectedValue);
+NIMBLE_SHORT(NMBObjCBeCloseToMatcher *beCloseTo(id expectedValue),
+             NMB_beCloseTo(expectedValue));
+
+NIMBLE_EXPORT id<NMBMatcher> NMB_beAnInstanceOf(Class expectedClass);
+NIMBLE_SHORT(id<NMBMatcher> beAnInstanceOf(Class expectedClass),
+             NMB_beAnInstanceOf(expectedClass));
+
+NIMBLE_EXPORT id<NMBMatcher> NMB_beAKindOf(Class expectedClass);
+NIMBLE_SHORT(id<NMBMatcher> beAKindOf(Class expectedClass),
+             NMB_beAKindOf(expectedClass));
+
+NIMBLE_EXPORT id<NMBMatcher> NMB_beginWith(id itemElementOrSubstring);
+NIMBLE_SHORT(id<NMBMatcher> beginWith(id itemElementOrSubstring),
+             NMB_beginWith(itemElementOrSubstring));
+
+NIMBLE_EXPORT id<NMBMatcher> NMB_beGreaterThan(NSNumber *expectedValue);
+NIMBLE_SHORT(id<NMBMatcher> beGreaterThan(NSNumber *expectedValue),
+             NMB_beGreaterThan(expectedValue));
+
+NIMBLE_EXPORT id<NMBMatcher> NMB_beGreaterThanOrEqualTo(NSNumber *expectedValue);
+NIMBLE_SHORT(id<NMBMatcher> beGreaterThanOrEqualTo(NSNumber *expectedValue),
+             NMB_beGreaterThanOrEqualTo(expectedValue));
+
+NIMBLE_EXPORT id<NMBMatcher> NMB_beIdenticalTo(id expectedInstance);
+NIMBLE_SHORT(id<NMBMatcher> beIdenticalTo(id expectedInstance),
+             NMB_beIdenticalTo(expectedInstance));
+
+NIMBLE_EXPORT id<NMBMatcher> NMB_beLessThan(NSNumber *expectedValue);
+NIMBLE_SHORT(id<NMBMatcher> beLessThan(NSNumber *expectedValue),
+             NMB_beLessThan(expectedValue));
+
+NIMBLE_EXPORT id<NMBMatcher> NMB_beLessThanOrEqualTo(NSNumber *expectedValue);
+NIMBLE_SHORT(id<NMBMatcher> beLessThanOrEqualTo(NSNumber *expectedValue),
+             NMB_beLessThanOrEqualTo(expectedValue));
+
+NIMBLE_EXPORT id<NMBMatcher> NMB_beTruthy(void);
+NIMBLE_SHORT(id<NMBMatcher> beTruthy(void),
+             NMB_beTruthy());
+
+NIMBLE_EXPORT id<NMBMatcher> NMB_beFalsy(void);
+NIMBLE_SHORT(id<NMBMatcher> beFalsy(void),
+             NMB_beFalsy());
+
+NIMBLE_EXPORT id<NMBMatcher> NMB_beTrue(void);
+NIMBLE_SHORT(id<NMBMatcher> beTrue(void),
+             NMB_beTrue());
+
+NIMBLE_EXPORT id<NMBMatcher> NMB_beFalse(void);
+NIMBLE_SHORT(id<NMBMatcher> beFalse(void),
+             NMB_beFalse());
+
+NIMBLE_EXPORT id<NMBMatcher> NMB_beNil(void);
+NIMBLE_SHORT(id<NMBMatcher> beNil(void),
+             NMB_beNil());
+
+NIMBLE_EXPORT id<NMBMatcher> NMB_beEmpty(void);
+NIMBLE_SHORT(id<NMBMatcher> beEmpty(void),
+             NMB_beEmpty());
+
+NIMBLE_EXPORT id<NMBMatcher> NMB_containWithNilTermination(id itemOrSubstring, ...) NS_REQUIRES_NIL_TERMINATION;
+#define NMB_contain(...) NMB_containWithNilTermination(__VA_ARGS__, nil)
+#ifndef NIMBLE_DISABLE_SHORT_SYNTAX
+#define contain(...) NMB_contain(__VA_ARGS__)
+#endif
+
+NIMBLE_EXPORT id<NMBMatcher> NMB_endWith(id itemElementOrSubstring);
+NIMBLE_SHORT(id<NMBMatcher> endWith(id itemElementOrSubstring),
+             NMB_endWith(itemElementOrSubstring));
+
+NIMBLE_EXPORT NMBObjCRaiseExceptionMatcher *NMB_raiseException(void);
+NIMBLE_SHORT(NMBObjCRaiseExceptionMatcher *raiseException(void),
+             NMB_raiseException());
+
+NIMBLE_EXPORT id<NMBMatcher> NMB_match(id expectedValue);
+NIMBLE_SHORT(id<NMBMatcher> match(id expectedValue),
+             NMB_match(expectedValue));
+
+NIMBLE_EXPORT id<NMBMatcher> NMB_allPass(id matcher);
+NIMBLE_SHORT(id<NMBMatcher> allPass(id matcher),
+             NMB_allPass(matcher));
+
+// In order to preserve breakpoint behavior despite using macros to fill in __FILE__ and __LINE__,
+// define a builder that populates __FILE__ and __LINE__, and returns a block that takes timeout
+// and action arguments. See https://github.com/Quick/Quick/pull/185 for details.
+typedef void (^NMBWaitUntilTimeoutBlock)(NSTimeInterval timeout, void (^action)(void (^)(void)));
+typedef void (^NMBWaitUntilBlock)(void (^action)(void (^)(void)));
+
+NIMBLE_EXPORT void NMB_failWithMessage(NSString *msg, NSString *file, NSUInteger line);
+
+NIMBLE_EXPORT NMBWaitUntilTimeoutBlock NMB_waitUntilTimeoutBuilder(NSString *file, NSUInteger line);
+NIMBLE_EXPORT NMBWaitUntilBlock NMB_waitUntilBuilder(NSString *file, NSUInteger line);
+
+NIMBLE_EXPORT void NMB_failWithMessage(NSString *msg, NSString *file, NSUInteger line);
+
+#define NMB_waitUntilTimeout NMB_waitUntilTimeoutBuilder(@(__FILE__), __LINE__)
+#define NMB_waitUntil NMB_waitUntilBuilder(@(__FILE__), __LINE__)
+
+#ifndef NIMBLE_DISABLE_SHORT_SYNTAX
+#define expect(...) NMB_expect(^id{ return (__VA_ARGS__); }, @(__FILE__), __LINE__)
+#define expectAction(BLOCK) NMB_expectAction((BLOCK), @(__FILE__), __LINE__)
+#define failWithMessage(msg) NMB_failWithMessage(msg, @(__FILE__), __LINE__)
+#define fail() failWithMessage(@"fail() always fails")
+
+
+#define waitUntilTimeout NMB_waitUntilTimeout
+#define waitUntil NMB_waitUntil
+#endif

--- a/Example/Pods/Headers/Private/Nimble/NMBExceptionCapture.h
+++ b/Example/Pods/Headers/Private/Nimble/NMBExceptionCapture.h
@@ -1,1 +1,8 @@
-../../../Nimble/Nimble/objc/NMBExceptionCapture.h
+#import <Foundation/Foundation.h>
+
+@interface NMBExceptionCapture : NSObject
+
+- (id)initWithHandler:(void(^)(NSException *))handler finally:(void(^)())finally;
+- (void)tryBlock:(void(^)())unsafeBlock;
+
+@end

--- a/Example/Pods/Headers/Private/Nimble/Nimble.h
+++ b/Example/Pods/Headers/Private/Nimble/Nimble.h
@@ -1,1 +1,6 @@
-../../../Nimble/Nimble/Nimble.h
+#import <Foundation/Foundation.h>
+#import "NMBExceptionCapture.h"
+#import "DSL.h"
+
+FOUNDATION_EXPORT double NimbleVersionNumber;
+FOUNDATION_EXPORT const unsigned char NimbleVersionString[];

--- a/Example/Pods/Headers/Private/Quick/NSString+QCKSelectorName.h
+++ b/Example/Pods/Headers/Private/Quick/NSString+QCKSelectorName.h
@@ -1,1 +1,17 @@
-../../../Quick/Quick/NSString+QCKSelectorName.h
+#import <Foundation/Foundation.h>
+
+/**
+ QuickSpec converts example names into test methods.
+ Those test methods need valid selector names, which means no whitespace,
+ control characters, etc. This category gives NSString objects an easy way
+ to replace those illegal characters with underscores.
+ */
+@interface NSString (QCKSelectorName)
+
+/**
+ Returns a string with underscores in place of all characters that cannot
+ be included in a selector (SEL) name.
+ */
+@property (nonatomic, readonly) NSString *qck_selectorName;
+
+@end

--- a/Example/Pods/Headers/Private/Quick/QCKDSL.h
+++ b/Example/Pods/Headers/Private/Quick/QCKDSL.h
@@ -1,1 +1,234 @@
-../../../Quick/Quick/DSL/QCKDSL.h
+#import <Foundation/Foundation.h>
+
+@class ExampleMetadata;
+
+/**
+ Provides a hook for Quick to be configured before any examples are run.
+ Within this scope, override the +[QuickConfiguration configure:] method
+ to set properties on a configuration object to customize Quick behavior.
+ For details, see the documentation for Configuraiton.swift.
+
+ @param name The name of the configuration class. Like any Objective-C
+             class name, this must be unique to the current runtime
+             environment.
+ */
+#define QuickConfigurationBegin(name) \
+    @interface name : QuickConfiguration; @end \
+    @implementation name \
+
+
+/**
+ Marks the end of a Quick configuration.
+ Make sure you put this after `QuickConfigurationBegin`.
+ */
+#define QuickConfigurationEnd \
+    @end \
+
+
+/**
+ Defines a new QuickSpec. Define examples and example groups within the space
+ between this and `QuickSpecEnd`.
+
+ @param name The name of the spec class. Like any Objective-C class name, this
+             must be unique to the current runtime environment.
+ */
+#define QuickSpecBegin(name) \
+    @interface name : QuickSpec; @end \
+    @implementation name \
+    - (void)spec { \
+
+
+/**
+ Marks the end of a QuickSpec. Make sure you put this after `QuickSpecBegin`.
+ */
+#define QuickSpecEnd \
+    } \
+    @end \
+
+typedef NSDictionary *(^QCKDSLSharedExampleContext)(void);
+typedef void (^QCKDSLSharedExampleBlock)(QCKDSLSharedExampleContext);
+typedef void (^QCKDSLEmptyBlock)(void);
+typedef void (^QCKDSLExampleMetadataBlock)(ExampleMetadata *exampleMetadata);
+
+#define QUICK_EXPORT FOUNDATION_EXPORT
+
+QUICK_EXPORT void qck_beforeSuite(QCKDSLEmptyBlock closure);
+QUICK_EXPORT void qck_afterSuite(QCKDSLEmptyBlock closure);
+QUICK_EXPORT void qck_sharedExamples(NSString *name, QCKDSLSharedExampleBlock closure);
+QUICK_EXPORT void qck_describe(NSString *description, QCKDSLEmptyBlock closure);
+QUICK_EXPORT void qck_context(NSString *description, QCKDSLEmptyBlock closure);
+QUICK_EXPORT void qck_beforeEach(QCKDSLEmptyBlock closure);
+QUICK_EXPORT void qck_beforeEachWithMetadata(QCKDSLExampleMetadataBlock closure);
+QUICK_EXPORT void qck_afterEach(QCKDSLEmptyBlock closure);
+QUICK_EXPORT void qck_afterEachWithMetadata(QCKDSLExampleMetadataBlock closure);
+QUICK_EXPORT void qck_pending(NSString *description, QCKDSLEmptyBlock closure);
+QUICK_EXPORT void qck_xdescribe(NSString *description, QCKDSLEmptyBlock closure);
+QUICK_EXPORT void qck_xcontext(NSString *description, QCKDSLEmptyBlock closure);
+QUICK_EXPORT void qck_fdescribe(NSString *description, QCKDSLEmptyBlock closure);
+QUICK_EXPORT void qck_fcontext(NSString *description, QCKDSLEmptyBlock closure);
+
+#ifndef QUICK_DISABLE_SHORT_SYNTAX
+/**
+    Defines a closure to be run prior to any examples in the test suite.
+    You may define an unlimited number of these closures, but there is no
+    guarantee as to the order in which they're run.
+ 
+    If the test suite crashes before the first example is run, this closure
+    will not be executed.
+ 
+    @param closure The closure to be run prior to any examples in the test suite.
+ */
+static inline void beforeSuite(QCKDSLEmptyBlock closure) {
+    qck_beforeSuite(closure);
+}
+
+
+/**
+    Defines a closure to be run after all of the examples in the test suite.
+    You may define an unlimited number of these closures, but there is no
+    guarantee as to the order in which they're run.
+     
+    If the test suite crashes before all examples are run, this closure
+    will not be executed.
+ 
+    @param closure The closure to be run after all of the examples in the test suite.
+ */
+static inline void afterSuite(QCKDSLEmptyBlock closure) {
+    qck_afterSuite(closure);
+}
+
+/**
+    Defines a group of shared examples. These examples can be re-used in several locations
+    by using the `itBehavesLike` function.
+ 
+    @param name The name of the shared example group. This must be unique across all shared example
+                groups defined in a test suite.
+    @param closure A closure containing the examples. This behaves just like an example group defined
+                   using `describe` or `context`--the closure may contain any number of `beforeEach`
+                   and `afterEach` closures, as well as any number of examples (defined using `it`).
+ */
+static inline void sharedExamples(NSString *name, QCKDSLSharedExampleBlock closure) {
+    qck_sharedExamples(name, closure);
+}
+
+/**
+    Defines an example group. Example groups are logical groupings of examples.
+    Example groups can share setup and teardown code.
+ 
+    @param description An arbitrary string describing the example group.
+    @param closure A closure that can contain other examples.
+ */
+static inline void describe(NSString *description, QCKDSLEmptyBlock closure) {
+    qck_describe(description, closure);
+}
+
+/**
+    Defines an example group. Equivalent to `describe`.
+ */
+static inline void context(NSString *description, QCKDSLEmptyBlock closure) {
+    qck_context(description, closure);
+}
+
+/**
+    Defines a closure to be run prior to each example in the current example
+    group. This closure is not run for pending or otherwise disabled examples.
+    An example group may contain an unlimited number of beforeEach. They'll be
+    run in the order they're defined, but you shouldn't rely on that behavior.
+ 
+    @param closure The closure to be run prior to each example.
+ */
+static inline void beforeEach(QCKDSLEmptyBlock closure) {
+    qck_beforeEach(closure);
+}
+
+/**
+    Identical to QCKDSL.beforeEach, except the closure is provided with
+    metadata on the example that the closure is being run prior to.
+ */
+static inline void beforeEachWithMetadata(QCKDSLExampleMetadataBlock closure) {
+    qck_beforeEachWithMetadata(closure);
+}
+
+/**
+    Defines a closure to be run after each example in the current example
+    group. This closure is not run for pending or otherwise disabled examples.
+    An example group may contain an unlimited number of afterEach. They'll be
+    run in the order they're defined, but you shouldn't rely on that behavior.
+ 
+    @param closure The closure to be run after each example.
+ */
+static inline void afterEach(QCKDSLEmptyBlock closure) {
+    qck_afterEach(closure);
+}
+
+/**
+    Identical to QCKDSL.afterEach, except the closure is provided with
+    metadata on the example that the closure is being run after.
+ */
+static inline void afterEachWithMetadata(QCKDSLExampleMetadataBlock closure) {
+    qck_afterEachWithMetadata(closure);
+}
+
+/**
+    Defines an example or example group that should not be executed. Use `pending` to temporarily disable
+    examples or groups that should not be run yet.
+ 
+    @param description An arbitrary string describing the example or example group.
+    @param closure A closure that will not be evaluated.
+ */
+static inline void pending(NSString *description, QCKDSLEmptyBlock closure) {
+    qck_pending(description, closure);
+}
+
+/**
+    Use this to quickly mark a `describe` block as pending.
+    This disables all examples within the block.
+ */
+static inline void xdescribe(NSString *description, QCKDSLEmptyBlock closure) {
+    qck_xdescribe(description, closure);
+}
+
+/**
+    Use this to quickly mark a `context` block as pending.
+    This disables all examples within the block.
+ */
+static inline void xcontext(NSString *description, QCKDSLEmptyBlock closure) {
+    qck_xcontext(description, closure);
+}
+
+/**
+    Use this to quickly focus a `describe` block, focusing the examples in the block.
+    If any examples in the test suite are focused, only those examples are executed.
+    This trumps any explicitly focused or unfocused examples within the block--they are all treated as focused.
+ */
+static inline void fdescribe(NSString *description, QCKDSLEmptyBlock closure) {
+    qck_fdescribe(description, closure);
+}
+
+/**
+    Use this to quickly focus a `context` block. Equivalent to `fdescribe`.
+ */
+static inline void fcontext(NSString *description, QCKDSLEmptyBlock closure) {
+    qck_fcontext(description, closure);
+}
+
+#define it qck_it
+#define xit qck_xit
+#define fit qck_fit
+#define itBehavesLike qck_itBehavesLike
+#define xitBehavesLike qck_xitBehavesLike
+#define fitBehavesLike qck_fitBehavesLike
+#endif
+
+#define qck_it qck_it_builder(@{}, @(__FILE__), __LINE__)
+#define qck_xit qck_it_builder(@{Filter.pending: @YES}, @(__FILE__), __LINE__)
+#define qck_fit qck_it_builder(@{Filter.focused: @YES}, @(__FILE__), __LINE__)
+#define qck_itBehavesLike qck_itBehavesLike_builder(@{}, @(__FILE__), __LINE__)
+#define qck_xitBehavesLike qck_itBehavesLike_builder(@{Filter.pending: @YES}, @(__FILE__), __LINE__)
+#define qck_fitBehavesLike qck_itBehavesLike_builder(@{Filter.focused: @YES}, @(__FILE__), __LINE__)
+
+typedef void (^QCKItBlock)(NSString *description, QCKDSLEmptyBlock closure);
+typedef void (^QCKItBehavesLikeBlock)(NSString *description, QCKDSLSharedExampleContext context);
+
+QUICK_EXPORT QCKItBlock qck_it_builder(NSDictionary *flags, NSString *file, NSUInteger line);
+QUICK_EXPORT QCKItBehavesLikeBlock qck_itBehavesLike_builder(NSDictionary *flags, NSString *file, NSUInteger line);

--- a/Example/Pods/Headers/Private/Quick/Quick.h
+++ b/Example/Pods/Headers/Private/Quick/Quick.h
@@ -1,1 +1,11 @@
-../../../Quick/Quick/Quick.h
+#import <Foundation/Foundation.h>
+
+//! Project version number for Quick.
+FOUNDATION_EXPORT double QuickVersionNumber;
+
+//! Project version string for Quick.
+FOUNDATION_EXPORT const unsigned char QuickVersionString[];
+
+#import "QuickSpec.h"
+#import "QCKDSL.h"
+#import "QuickConfiguration.h"

--- a/Example/Pods/Headers/Private/Quick/QuickConfiguration.h
+++ b/Example/Pods/Headers/Private/Quick/QuickConfiguration.h
@@ -1,1 +1,30 @@
-../../../Quick/Quick/Configuration/QuickConfiguration.h
+#import <Foundation/Foundation.h>
+
+@class Configuration;
+
+/**
+ Subclass QuickConfiguration and override the +[QuickConfiguration configure:]
+ method in order to configure how Quick behaves when running specs, or to define
+ shared examples that are used across spec files.
+ */
+@interface QuickConfiguration : NSObject
+
+/**
+ This method is executed on each subclass of this class before Quick runs
+ any examples. You may override this method on as many subclasses as you like, but
+ there is no guarantee as to the order in which these methods are executed.
+
+ You can override this method in order to:
+
+ 1. Configure how Quick behaves, by modifying properties on the Configuration object.
+    Setting the same properties in several methods has undefined behavior.
+
+ 2. Define shared examples using `sharedExamples`.
+
+ @param configuration A mutable object that is used to configure how Quick behaves on
+                      a framework level. For details on all the options, see the
+                      documentation in Configuration.swift.
+ */
++ (void)configure:(Configuration *)configuration;
+
+@end

--- a/Example/Pods/Headers/Private/Quick/QuickSpec.h
+++ b/Example/Pods/Headers/Private/Quick/QuickSpec.h
@@ -1,1 +1,48 @@
-../../../Quick/Quick/QuickSpec.h
+#import <XCTest/XCTest.h>
+
+/**
+ QuickSpec is a base class all specs written in Quick inherit from.
+ They need to inherit from QuickSpec, a subclass of XCTestCase, in
+ order to be discovered by the XCTest framework.
+
+ XCTest automatically compiles a list of XCTestCase subclasses included
+ in the test target. It iterates over each class in that list, and creates
+ a new instance of that class for each test method. It then creates an
+ "invocation" to execute that test method. The invocation is an instance of
+ NSInvocation, which represents a single message send in Objective-C.
+ The invocation is set on the XCTestCase instance, and the test is run.
+
+ Most of the code in QuickSpec is dedicated to hooking into XCTest events.
+ First, when the spec is first loaded and before it is sent any messages,
+ the +[NSObject initialize] method is called. QuickSpec overrides this method
+ to call +[QuickSpec spec]. This builds the example group stacks and
+ registers them with Quick.World, a global register of examples.
+
+ Then, XCTest queries QuickSpec for a list of test methods. Normally, XCTest
+ automatically finds all methods whose selectors begin with the string "test".
+ However, QuickSpec overrides this default behavior by implementing the
+ +[XCTestCase testInvocations] method. This method iterates over each example
+ registered in Quick.World, defines a new method for that example, and
+ returns an invocation to call that method to XCTest. Those invocations are
+ the tests that are run by XCTest. Their selector names are displayed in
+ the Xcode test navigation bar.
+ */
+@interface QuickSpec : XCTestCase
+
+/**
+ Override this method in your spec to define a set of example groups
+ and examples.
+
+     override class func spec() {
+         describe("winter") {
+             it("is coming") {
+                 // ...
+             }
+         }
+     }
+
+ See DSL.swift for more information on what syntax is available.
+ */
+- (void)spec;
+
+@end

--- a/Example/Pods/Headers/Private/Quick/World+DSL.h
+++ b/Example/Pods/Headers/Private/Quick/World+DSL.h
@@ -1,1 +1,20 @@
-../../../Quick/Quick/DSL/World+DSL.h
+#import <Quick/Quick-Swift.h>
+
+@interface World (SWIFT_EXTENSION(Quick))
+- (void)beforeSuite:(void (^ __nonnull)(void))closure;
+- (void)afterSuite:(void (^ __nonnull)(void))closure;
+- (void)sharedExamples:(NSString * __nonnull)name closure:(void (^ __nonnull)(NSDictionary * __nonnull (^ __nonnull)(void)))closure;
+- (void)describe:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags closure:(void (^ __nonnull)(void))closure;
+- (void)context:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags closure:(void (^ __nonnull)(void))closure;
+- (void)fdescribe:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags closure:(void (^ __nonnull)(void))closure;
+- (void)xdescribe:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags closure:(void (^ __nonnull)(void))closure;
+- (void)beforeEach:(void (^ __nonnull)(void))closure;
+- (void)beforeEachWithMetadata:(void (^ __nonnull)(ExampleMetadata * __nonnull))closure;
+- (void)afterEach:(void (^ __nonnull)(void))closure;
+- (void)afterEachWithMetadata:(void (^ __nonnull)(ExampleMetadata * __nonnull))closure;
+- (void)itWithDescription:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags file:(NSString * __nonnull)file line:(NSUInteger)line closure:(void (^ __nonnull)(void))closure;
+- (void)fitWithDescription:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags file:(NSString * __nonnull)file line:(NSUInteger)line closure:(void (^ __nonnull)(void))closure;
+- (void)xitWithDescription:(NSString * __nonnull)description flags:(NSDictionary * __nonnull)flags file:(NSString * __nonnull)file line:(NSUInteger)line closure:(void (^ __nonnull)(void))closure;
+- (void)itBehavesLikeSharedExampleNamed:(NSString * __nonnull)name sharedExampleContext:(NSDictionary * __nonnull (^ __nonnull)(void))sharedExampleContext flags:(NSDictionary * __nonnull)flags file:(NSString * __nonnull)file line:(NSUInteger)line;
+- (void)pending:(NSString * __nonnull)description closure:(void (^ __nonnull)(void))closure;
+@end

--- a/Example/Pods/Headers/Private/Quick/World.h
+++ b/Example/Pods/Headers/Private/Quick/World.h
@@ -1,1 +1,17 @@
-../../../Quick/Quick/World.h
+#import <Quick/Quick-Swift.h>
+
+@class ExampleGroup;
+@class ExampleMetadata;
+
+SWIFT_CLASS("_TtC5Quick5World")
+@interface World
+
+@property (nonatomic) ExampleGroup * __nullable currentExampleGroup;
+@property (nonatomic) ExampleMetadata * __nullable currentExampleMetadata;
+@property (nonatomic) BOOL isRunningAdditionalSuites;
++ (World * __nonnull)sharedWorld;
+- (void)configure:(void (^ __nonnull)(Configuration * __nonnull))closure;
+- (void)finalizeConfiguration;
+- (ExampleGroup * __nonnull)rootExampleGroupForSpecClass:(Class __nonnull)cls;
+- (NSArray * __nonnull)examplesForSpecClass:(Class __nonnull)specClass;
+@end

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015 git <dtrenz@gmail.com>
+Copyright (c) 2015 Dan Trenz <dtrenz@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Pod/Classes/BugShaker.swift
+++ b/Pod/Classes/BugShaker.swift
@@ -151,7 +151,7 @@ extension UIViewController: MFMailComposeViewControllerDelegate {
 
     // MARK: - MFMailComposeViewControllerDelegate
 
-    override public func mailComposeController(controller: MFMailComposeViewController,
+    public func mailComposeController(controller: MFMailComposeViewController,
                                                didFinishWithResult result: MFMailComposeResult,
                                                                    error: NSError?) {
         if let error = error {

--- a/Pod/Classes/BugShaker.swift
+++ b/Pod/Classes/BugShaker.swift
@@ -22,12 +22,12 @@ public class BugShaker {
     static var subject: String?
     static var body: String?
   }
-  
+
   // MARK: - Configuration
-  
+
   /**
   Set bug report email recipient(s), custom subject line and body.
-  
+
   - parameter toRecipients: List of email addresses to which the report will be sent.
   - parameter subject:      Custom subject line to use for the report email.
   - parameter body:         Custom email body (plain text).
@@ -38,17 +38,17 @@ public class BugShaker {
     Config.body = body
     BugShaker.delegate = delegate
   }
-  
+
 }
 
 extension UIViewController: MFMailComposeViewControllerDelegate {
-  
+
   // MARK: - UIResponder
-  
+
   override public func canBecomeFirstResponder() -> Bool {
     return true
   }
-  
+
   override public func motionEnded(motion: UIEventSubtype, withEvent event: UIEvent?) {
     if motion == .MotionShake {
       if let delegate = BugShaker.delegate {
@@ -64,99 +64,105 @@ extension UIViewController: MFMailComposeViewControllerDelegate {
       })
     }
   }
-  
+
   // MARK: - Alert
-  
+
   func presentReportPrompt(reportActionHandler: (UIAlertAction) -> Void) {
-    let actionSheet = UIAlertController(title: "Shake detected!", message: "Would you like to report a bug?", preferredStyle: .ActionSheet)
-    
+    let actionSheet = UIAlertController(
+      title: "Shake detected!",
+      message: "Would you like to report a bug?",
+      preferredStyle: .ActionSheet
+    )
+
     let reportAction = UIAlertAction(title: "Report A Bug", style: .Default, handler: reportActionHandler)
     let cancelAction = UIAlertAction(title: "Cancel", style: .Cancel) { _ in }
-    
+
     actionSheet.addAction(reportAction)
     actionSheet.addAction(cancelAction)
-    
+
     presentViewController(actionSheet, animated: true, completion: nil)
   }
-  
-  
+
+
   // MARK: - Report methods
-  
+
   /**
   Take a screenshot for the current screen state.
-  
+
   - returns: Screenshot image.
   */
   func captureScreenshot() -> UIImage? {
     var screenshot: UIImage? = nil
-    
+
     if let layer = UIApplication.sharedApplication().keyWindow?.layer {
       let scale = UIScreen.mainScreen().scale
-      
+
       UIGraphicsBeginImageContextWithOptions(layer.frame.size, false, scale);
-      
+
       if let context = UIGraphicsGetCurrentContext() {
         layer.renderInContext(context)
       }
-      
+
       screenshot = UIGraphicsGetImageFromCurrentImageContext()
-      
+
       UIGraphicsEndImageContext()
     }
-    
+
     return screenshot;
   }
-  
+
   /**
    Present the user with a mail compose view with the recipient(s), subject line and body
    pre-populated, and the screenshot attached.
-   
+
    - parameter screenshot: The screenshot to attach to the report.
    */
   func presentReportComposeView(screenshot: UIImage?) {
     if MFMailComposeViewController.canSendMail() {
       let mailComposer = MFMailComposeViewController()
-      
+
       guard let toRecipients = BugShaker.Config.toRecipients else {
         print("BugShaker – Error: No recipients provided. Make sure that BugShaker.configure() is called.")
         return
       }
-      
+
       mailComposer.setToRecipients(toRecipients)
       mailComposer.setSubject(BugShaker.Config.subject ?? "Bug Report")
       mailComposer.setMessageBody(BugShaker.Config.body ?? "", isHTML: false)
       mailComposer.mailComposeDelegate = self
-      
+
       if let screenshot = screenshot, let screenshotJPEG = UIImageJPEGRepresentation(screenshot, CGFloat(1.0)) {
         mailComposer.addAttachmentData(screenshotJPEG, mimeType: "image/jpeg", fileName: "screenshot.jpeg")
       }
-      
+
       presentViewController(mailComposer, animated: true, completion: nil)
     }
   }
-  
+
   // MARK: - MFMailComposeViewControllerDelegate
-  
-  public func mailComposeController(controller: MFMailComposeViewController, didFinishWithResult result: MFMailComposeResult, error: NSError?) {
+
+  public func mailComposeController(controller: MFMailComposeViewController,
+                                    result: MFMailComposeResult,
+                                    error: NSError?) {
     if let error = error {
       print("BugShaker – Error: \(error)")
     }
-    
+
     switch result {
     case MFMailComposeResultFailed:
       print("BugShaker – Bug report send failed.")
       break;
-      
+
     case MFMailComposeResultSent:
       print("BugShaker – Bug report sent!")
       break;
-      
+
     default:
       // noop
       break;
     }
-    
+
     dismissViewControllerAnimated(true, completion: nil)
   }
-  
+
 }

--- a/Pod/Classes/BugShaker.swift
+++ b/Pod/Classes/BugShaker.swift
@@ -8,12 +8,16 @@
 import UIKit
 import MessageUI
 
+public protocol BugShakerDelegate {
+  func ShouldPresentReportPrompt() -> Bool
+}
 
 public class BugShaker {
-  
+
   struct Config {
     static var toRecipients: [String]?
     static var subject: String?
+    static var delegate: BugShakerDelegate?
   }
   
   // MARK: - Configuration
@@ -24,9 +28,10 @@ public class BugShaker {
   - parameter toRecipients: List of email addresses to which the report will be sent.
   - parameter subject:      Custom subject line to use for the report email.
   */
-  public class func configure(to toRecipients: [String]!, subject: String?) {
+    public class func configure(to toRecipients: [String]!, subject: String?, delegate: BugShakerDelegate? = nil) {
     Config.toRecipients = toRecipients
     Config.subject = subject
+    Config.delegate = delegate
   }
   
 }
@@ -42,7 +47,13 @@ extension UIViewController: MFMailComposeViewControllerDelegate {
   override public func motionEnded(motion: UIEventSubtype, withEvent event: UIEvent?) {
     if motion == .MotionShake {
       let cachedScreenshot = captureScreenshot()
-      
+
+      if let delegate = BugShaker.Config.delegate {
+        if (!delegate.ShouldPresentReportPrompt()) {
+          return
+        }
+      }
+
       presentReportPrompt({ (action) -> Void in
         self.presentReportComposeView(cachedScreenshot)
       })

--- a/Pod/Classes/BugShaker.swift
+++ b/Pod/Classes/BugShaker.swift
@@ -31,7 +31,7 @@ public class BugShaker {
   - parameter body:         Custom email body (plain text).
   - parameter delegate:     optional delegate object that implements ShouldPresentReportPorompt and can basically disable or enable the bugshaker behavior
   */
-    public class func configure(to toRecipients: [String]!, subject: String?, body: String?, delegate: BugShakerDelegate? = nil) {
+  public class func configure(to toRecipients: [String]!, subject: String?, body: String?, delegate: BugShakerDelegate? = nil) {
     Config.toRecipients = toRecipients
     Config.subject = subject
     Config.body = body

--- a/Pod/Classes/BugShaker.swift
+++ b/Pod/Classes/BugShaker.swift
@@ -9,15 +9,17 @@ import UIKit
 import MessageUI
 
 public protocol BugShakerDelegate {
-  func ShouldPresentReportPrompt() -> Bool
+  func shouldPresentReportPrompt() -> Bool
 }
 
 public class BugShaker {
 
+  // optional delegate object that implements ShouldPresentReportPorompt and can basically disable or enable the bugshaker behavior
+  static var delegate: BugShakerDelegate?
+
   struct Config {
     static var toRecipients: [String]?
     static var subject: String?
-    static var delegate: BugShakerDelegate?
     static var body: String?
   }
   
@@ -29,13 +31,12 @@ public class BugShaker {
   - parameter toRecipients: List of email addresses to which the report will be sent.
   - parameter subject:      Custom subject line to use for the report email.
   - parameter body:         Custom email body (plain text).
-  - parameter delegate:     optional delegate object that implements ShouldPresentReportPorompt and can basically disable or enable the bugshaker behavior
   */
   public class func configure(to toRecipients: [String]!, subject: String?, body: String?, delegate: BugShakerDelegate? = nil) {
     Config.toRecipients = toRecipients
     Config.subject = subject
     Config.body = body
-    Config.delegate = delegate
+    BugShaker.delegate = delegate
   }
   
 }
@@ -50,13 +51,13 @@ extension UIViewController: MFMailComposeViewControllerDelegate {
   
   override public func motionEnded(motion: UIEventSubtype, withEvent event: UIEvent?) {
     if motion == .MotionShake {
-      let cachedScreenshot = captureScreenshot()
-
-      if let delegate = BugShaker.Config.delegate {
-        if (!delegate.ShouldPresentReportPrompt()) {
+      if let delegate = BugShaker.delegate {
+        if !delegate.shouldPresentReportPrompt() {
           return
         }
       }
+
+      let cachedScreenshot = captureScreenshot()
 
       presentReportPrompt({ (action) -> Void in
         self.presentReportComposeView(cachedScreenshot)

--- a/Pod/Classes/BugShaker.swift
+++ b/Pod/Classes/BugShaker.swift
@@ -13,21 +13,21 @@ public protocol BugShakerDelegate {
 }
 
 public class BugShaker {
-    
+
     // optional delegate object that implements ShouldPresentReportPorompt and can basically disable or enable the bugshaker behavior
     static var delegate: BugShakerDelegate?
-    
+
     struct Config {
         static var toRecipients: [String]?
         static var subject: String?
         static var body: String?
     }
-    
+
     // MARK: - Configuration
-    
+
     /**
      Set bug report email recipient(s), custom subject line and body.
-     
+
      - parameter toRecipients: List of email addresses to which the report will be sent.
      - parameter subject:      Custom subject line to use for the report email.
      - parameter body:         Custom email body (plain text).
@@ -38,17 +38,17 @@ public class BugShaker {
         Config.body = body
         BugShaker.delegate = delegate
     }
-    
+
 }
 
 extension UIViewController: MFMailComposeViewControllerDelegate {
-    
+
     // MARK: - UIResponder
-    
+
     override public func canBecomeFirstResponder() -> Bool {
         return true
     }
-    
+
     override public func motionEnded(motion: UIEventSubtype, withEvent event: UIEvent?) {
         if motion == .MotionShake {
             if let delegate = BugShaker.delegate {
@@ -56,22 +56,22 @@ extension UIViewController: MFMailComposeViewControllerDelegate {
                     return
                 }
             }
-            
+
             let cachedScreenshot = captureScreenshot()
-            
+
             presentReportPrompt({ (action) -> Void in
                 self.presentReportComposeView(cachedScreenshot)
             })
         }
     }
-    
+
     // MARK: - Alert
-    
+
     func presentReportPrompt(reportActionHandler: (UIAlertAction) -> Void) {
-        
+
         let reportAction = UIAlertAction(title: "Report A Bug", style: .Default, handler: reportActionHandler)
         let cancelAction = UIAlertAction(title: "Cancel", style: .Cancel) { _ in }
-        
+
         if UIDevice.currentDevice().userInterfaceIdiom == .Phone {
             let actionSheet = UIAlertController(
                 title: "Shake detected!",
@@ -93,85 +93,85 @@ extension UIViewController: MFMailComposeViewControllerDelegate {
             self.presentViewController(actionSheet, animated: true, completion: nil)
         }
     }
-    
+
     // MARK: - Report methods
-    
+
     /**
      Take a screenshot for the current screen state.
-     
+
      - returns: Screenshot image.
      */
     func captureScreenshot() -> UIImage? {
         var screenshot: UIImage? = nil
-        
+
         if let layer = UIApplication.sharedApplication().keyWindow?.layer {
             let scale = UIScreen.mainScreen().scale
-            
+
             UIGraphicsBeginImageContextWithOptions(layer.frame.size, false, scale);
-            
+
             if let context = UIGraphicsGetCurrentContext() {
                 layer.renderInContext(context)
             }
-            
+
             screenshot = UIGraphicsGetImageFromCurrentImageContext()
-            
+
             UIGraphicsEndImageContext()
         }
-        
+
         return screenshot;
     }
-    
+
     /**
      Present the user with a mail compose view with the recipient(s), subject line and body
      pre-populated, and the screenshot attached.
-     
+
      - parameter screenshot: The screenshot to attach to the report.
      */
     func presentReportComposeView(screenshot: UIImage?) {
         if MFMailComposeViewController.canSendMail() {
             let mailComposer = MFMailComposeViewController()
-            
+
             guard let toRecipients = BugShaker.Config.toRecipients else {
                 print("BugShaker – Error: No recipients provided. Make sure that BugShaker.configure() is called.")
                 return
             }
-            
+
             mailComposer.setToRecipients(toRecipients)
             mailComposer.setSubject(BugShaker.Config.subject ?? "Bug Report")
             mailComposer.setMessageBody(BugShaker.Config.body ?? "", isHTML: false)
             mailComposer.mailComposeDelegate = self
-            
+
             if let screenshot = screenshot, let screenshotJPEG = UIImageJPEGRepresentation(screenshot, CGFloat(1.0)) {
                 mailComposer.addAttachmentData(screenshotJPEG, mimeType: "image/jpeg", fileName: "screenshot.jpeg")
             }
-            
+
             presentViewController(mailComposer, animated: true, completion: nil)
         }
     }
-    
+
     // MARK: - MFMailComposeViewControllerDelegate
-    
-    public func mailComposeController(controller: MFMailComposeViewController,
-                                      result: MFMailComposeResult,
-                                      error: NSError?) {
+
+    override public func mailComposeController(controller: MFMailComposeViewController,
+                                               didFinishWithResult result: MFMailComposeResult,
+                                                                   error: NSError?) {
         if let error = error {
             print("BugShaker – Error: \(error)")
         }
-        
+
         switch result {
         case MFMailComposeResultFailed:
             print("BugShaker – Bug report send failed.")
             break;
-            
+
         case MFMailComposeResultSent:
             print("BugShaker – Bug report sent!")
             break;
-            
+
         default:
             // noop
             break;
         }
-        
+
         dismissViewControllerAnimated(true, completion: nil)
     }
     

--- a/Pod/Classes/BugShaker.swift
+++ b/Pod/Classes/BugShaker.swift
@@ -9,160 +9,170 @@ import UIKit
 import MessageUI
 
 public protocol BugShakerDelegate {
-  func shouldPresentReportPrompt() -> Bool
+    func shouldPresentReportPrompt() -> Bool
 }
 
 public class BugShaker {
-
-  // optional delegate object that implements ShouldPresentReportPorompt and can basically disable or enable the bugshaker behavior
-  static var delegate: BugShakerDelegate?
-
-  struct Config {
-    static var toRecipients: [String]?
-    static var subject: String?
-    static var body: String?
-  }
-
-  // MARK: - Configuration
-
-  /**
-  Set bug report email recipient(s), custom subject line and body.
-
-  - parameter toRecipients: List of email addresses to which the report will be sent.
-  - parameter subject:      Custom subject line to use for the report email.
-  - parameter body:         Custom email body (plain text).
-  */
-  public class func configure(to toRecipients: [String]!, subject: String?, body: String?, delegate: BugShakerDelegate? = nil) {
-    Config.toRecipients = toRecipients
-    Config.subject = subject
-    Config.body = body
-    BugShaker.delegate = delegate
-  }
-
+    
+    // optional delegate object that implements ShouldPresentReportPorompt and can basically disable or enable the bugshaker behavior
+    static var delegate: BugShakerDelegate?
+    
+    struct Config {
+        static var toRecipients: [String]?
+        static var subject: String?
+        static var body: String?
+    }
+    
+    // MARK: - Configuration
+    
+    /**
+     Set bug report email recipient(s), custom subject line and body.
+     
+     - parameter toRecipients: List of email addresses to which the report will be sent.
+     - parameter subject:      Custom subject line to use for the report email.
+     - parameter body:         Custom email body (plain text).
+     */
+    public class func configure(to toRecipients: [String]!, subject: String?, body: String?, delegate: BugShakerDelegate? = nil) {
+        Config.toRecipients = toRecipients
+        Config.subject = subject
+        Config.body = body
+        BugShaker.delegate = delegate
+    }
+    
 }
 
 extension UIViewController: MFMailComposeViewControllerDelegate {
-
-  // MARK: - UIResponder
-
-  override public func canBecomeFirstResponder() -> Bool {
-    return true
-  }
-
-  override public func motionEnded(motion: UIEventSubtype, withEvent event: UIEvent?) {
-    if motion == .MotionShake {
-      if let delegate = BugShaker.delegate {
-        if !delegate.shouldPresentReportPrompt() {
-          return
+    
+    // MARK: - UIResponder
+    
+    override public func canBecomeFirstResponder() -> Bool {
+        return true
+    }
+    
+    override public func motionEnded(motion: UIEventSubtype, withEvent event: UIEvent?) {
+        if motion == .MotionShake {
+            if let delegate = BugShaker.delegate {
+                if !delegate.shouldPresentReportPrompt() {
+                    return
+                }
+            }
+            
+            let cachedScreenshot = captureScreenshot()
+            
+            presentReportPrompt({ (action) -> Void in
+                self.presentReportComposeView(cachedScreenshot)
+            })
         }
-      }
-
-      let cachedScreenshot = captureScreenshot()
-
-      presentReportPrompt({ (action) -> Void in
-        self.presentReportComposeView(cachedScreenshot)
-      })
     }
-  }
-
-  // MARK: - Alert
-
-  func presentReportPrompt(reportActionHandler: (UIAlertAction) -> Void) {
-    let actionSheet = UIAlertController(
-      title: "Shake detected!",
-      message: "Would you like to report a bug?",
-      preferredStyle: .ActionSheet
-    )
-
-    let reportAction = UIAlertAction(title: "Report A Bug", style: .Default, handler: reportActionHandler)
-    let cancelAction = UIAlertAction(title: "Cancel", style: .Cancel) { _ in }
-
-    actionSheet.addAction(reportAction)
-    actionSheet.addAction(cancelAction)
-
-    presentViewController(actionSheet, animated: true, completion: nil)
-  }
-
-
-  // MARK: - Report methods
-
-  /**
-  Take a screenshot for the current screen state.
-
-  - returns: Screenshot image.
-  */
-  func captureScreenshot() -> UIImage? {
-    var screenshot: UIImage? = nil
-
-    if let layer = UIApplication.sharedApplication().keyWindow?.layer {
-      let scale = UIScreen.mainScreen().scale
-
-      UIGraphicsBeginImageContextWithOptions(layer.frame.size, false, scale);
-
-      if let context = UIGraphicsGetCurrentContext() {
-        layer.renderInContext(context)
-      }
-
-      screenshot = UIGraphicsGetImageFromCurrentImageContext()
-
-      UIGraphicsEndImageContext()
+    
+    // MARK: - Alert
+    
+    func presentReportPrompt(reportActionHandler: (UIAlertAction) -> Void) {
+        
+        let reportAction = UIAlertAction(title: "Report A Bug", style: .Default, handler: reportActionHandler)
+        let cancelAction = UIAlertAction(title: "Cancel", style: .Cancel) { _ in }
+        
+        if UIDevice.currentDevice().userInterfaceIdiom == .Phone {
+            let actionSheet = UIAlertController(
+                title: "Shake detected!",
+                message: "Would you like to report a bug?",
+                preferredStyle: .ActionSheet
+            )
+            actionSheet.addAction(reportAction)
+            actionSheet.addAction(cancelAction)
+            self.presentViewController(actionSheet, animated: true, completion: nil)
+        }
+        else {
+            let actionSheet = UIAlertController(
+                title: "Shake detected!",
+                message: "Would you like to report a bug?",
+                preferredStyle: .Alert
+            )
+            actionSheet.addAction(reportAction)
+            actionSheet.addAction(cancelAction)
+            self.presentViewController(actionSheet, animated: true, completion: nil)
+        }
     }
-
-    return screenshot;
-  }
-
-  /**
-   Present the user with a mail compose view with the recipient(s), subject line and body
-   pre-populated, and the screenshot attached.
-
-   - parameter screenshot: The screenshot to attach to the report.
-   */
-  func presentReportComposeView(screenshot: UIImage?) {
-    if MFMailComposeViewController.canSendMail() {
-      let mailComposer = MFMailComposeViewController()
-
-      guard let toRecipients = BugShaker.Config.toRecipients else {
-        print("BugShaker – Error: No recipients provided. Make sure that BugShaker.configure() is called.")
-        return
-      }
-
-      mailComposer.setToRecipients(toRecipients)
-      mailComposer.setSubject(BugShaker.Config.subject ?? "Bug Report")
-      mailComposer.setMessageBody(BugShaker.Config.body ?? "", isHTML: false)
-      mailComposer.mailComposeDelegate = self
-
-      if let screenshot = screenshot, let screenshotJPEG = UIImageJPEGRepresentation(screenshot, CGFloat(1.0)) {
-        mailComposer.addAttachmentData(screenshotJPEG, mimeType: "image/jpeg", fileName: "screenshot.jpeg")
-      }
-
-      presentViewController(mailComposer, animated: true, completion: nil)
+    
+    // MARK: - Report methods
+    
+    /**
+     Take a screenshot for the current screen state.
+     
+     - returns: Screenshot image.
+     */
+    func captureScreenshot() -> UIImage? {
+        var screenshot: UIImage? = nil
+        
+        if let layer = UIApplication.sharedApplication().keyWindow?.layer {
+            let scale = UIScreen.mainScreen().scale
+            
+            UIGraphicsBeginImageContextWithOptions(layer.frame.size, false, scale);
+            
+            if let context = UIGraphicsGetCurrentContext() {
+                layer.renderInContext(context)
+            }
+            
+            screenshot = UIGraphicsGetImageFromCurrentImageContext()
+            
+            UIGraphicsEndImageContext()
+        }
+        
+        return screenshot;
     }
-  }
-
-  // MARK: - MFMailComposeViewControllerDelegate
-
-  public func mailComposeController(controller: MFMailComposeViewController,
-                                    result: MFMailComposeResult,
-                                    error: NSError?) {
-    if let error = error {
-      print("BugShaker – Error: \(error)")
+    
+    /**
+     Present the user with a mail compose view with the recipient(s), subject line and body
+     pre-populated, and the screenshot attached.
+     
+     - parameter screenshot: The screenshot to attach to the report.
+     */
+    func presentReportComposeView(screenshot: UIImage?) {
+        if MFMailComposeViewController.canSendMail() {
+            let mailComposer = MFMailComposeViewController()
+            
+            guard let toRecipients = BugShaker.Config.toRecipients else {
+                print("BugShaker – Error: No recipients provided. Make sure that BugShaker.configure() is called.")
+                return
+            }
+            
+            mailComposer.setToRecipients(toRecipients)
+            mailComposer.setSubject(BugShaker.Config.subject ?? "Bug Report")
+            mailComposer.setMessageBody(BugShaker.Config.body ?? "", isHTML: false)
+            mailComposer.mailComposeDelegate = self
+            
+            if let screenshot = screenshot, let screenshotJPEG = UIImageJPEGRepresentation(screenshot, CGFloat(1.0)) {
+                mailComposer.addAttachmentData(screenshotJPEG, mimeType: "image/jpeg", fileName: "screenshot.jpeg")
+            }
+            
+            presentViewController(mailComposer, animated: true, completion: nil)
+        }
     }
-
-    switch result {
-    case MFMailComposeResultFailed:
-      print("BugShaker – Bug report send failed.")
-      break;
-
-    case MFMailComposeResultSent:
-      print("BugShaker – Bug report sent!")
-      break;
-
-    default:
-      // noop
-      break;
+    
+    // MARK: - MFMailComposeViewControllerDelegate
+    
+    public func mailComposeController(controller: MFMailComposeViewController,
+                                      result: MFMailComposeResult,
+                                      error: NSError?) {
+        if let error = error {
+            print("BugShaker – Error: \(error)")
+        }
+        
+        switch result {
+        case MFMailComposeResultFailed:
+            print("BugShaker – Bug report send failed.")
+            break;
+            
+        case MFMailComposeResultSent:
+            print("BugShaker – Bug report sent!")
+            break;
+            
+        default:
+            // noop
+            break;
+        }
+        
+        dismissViewControllerAnimated(true, completion: nil)
     }
-
-    dismissViewControllerAnimated(true, completion: nil)
-  }
-
+    
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BugShaker
 
-[![CI Status](http://img.shields.io/travis/detroit-labs/BugShaker.svg?style=flat)](https://travis-ci.org/detroit-labs/BugShaker)
+[![CI Status](http://img.shields.io/travis/dtrenz/BugShaker.svg?style=flat)](https://travis-ci.org/dtrenz/BugShaker)
 [![Version](https://img.shields.io/cocoapods/v/BugShaker.svg?style=flat)](http://cocoapods.org/pods/BugShaker)
 [![License](https://img.shields.io/cocoapods/l/BugShaker.svg?style=flat)](http://cocoapods.org/pods/BugShaker)
 [![Platform](https://img.shields.io/cocoapods/p/BugShaker.svg?style=flat)](http://cocoapods.org/pods/BugShaker)
@@ -9,10 +9,12 @@ BugShaker allows your users to simply submit bug reports by shaking the device.
 When a shake is detected, the current screen state is captured and the user is
 prompted to submit a bug report via a mail composer with the screenshot attached.
 
+**Android developers:** If you are looking for an Android library with similar functionality, check out [stkent/bugshaker-android](https://github.com/stkent/bugshaker-android).
+
 ## Screenshots
 
-![Report Prompt](https://github.com/detroit-labs/BugShaker/blob/master/screenshot-1.png)
-![Report Compose View](https://github.com/detroit-labs/BugShaker/blob/master/screenshot-2.png)
+![Report Prompt](https://github.com/dtrenz/BugShaker/blob/master/screenshot-1.png)
+![Report Compose View](https://github.com/dtrenz/BugShaker/blob/master/screenshot-2.png)
 
 ## Usage
 
@@ -79,7 +81,7 @@ passing in the array of email recipients and an optional custom subject line:
 
 
 **NOTE:** There is a known issue with using a mail compose view controller in a simulator
-which causes some simulators simulator to crash. You will need to run the example on a
+which causes some simulators to crash. You will need to run the example on a
 device to test out the full report compose view functionality.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ All you have to do to enable bug reporting is import `BugShaker` in your `AppDel
 and call the `configure()` method in `application:didFinishLaunchingWithOptions`,
 passing in the array of email recipients and an optional custom subject line:
 
+
+### Basic usage
+
 ```swift
   import BugShaker
 
@@ -42,6 +45,38 @@ passing in the array of email recipients and an optional custom subject line:
 
   }
 ```
+
+### Advanced usage
+
+```swift
+  import BugShaker
+
+  @UIApplicationMain
+  class AppDelegate: UIResponder, UIApplicationDelegate, BugShakerDelegate {
+
+    var window: UIWindow?
+
+    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+      /**
+      *  Configure ShakeReport with an array of email recipients (required)
+      *  and an optional custom subject line to use for all bug reports.
+      */
+      BugShaker.configure(to: ["example@email.com"], subject: "Bug Report", body: "Hi there, I am reporting a bug in which ...", delegate: self)
+
+      return true
+    }
+
+    func shouldPresentReportPrompt() -> Bool {
+        // here you can read some settings from user defaults and decide if you want to have the bug report alert to show up or not
+        if NSUserDefaults.standardUserDefaults().stringForKey("CONFIG_ENABLE_BUGSHAKE") != "\(true)" {
+            return false
+        }
+        return true
+    }
+
+  }
+```
+
 
 **NOTE:** There is a known issue with using a mail compose view controller in a simulator
 which causes some simulators simulator to crash. You will need to run the example on a

--- a/_Pods.xcodeproj
+++ b/_Pods.xcodeproj
@@ -1,1 +1,0 @@
-Example/Pods/Pods.xcodeproj

--- a/_pods.xcodeproj/project.pbxproj
+++ b/_pods.xcodeproj/project.pbxproj
@@ -1,0 +1,1273 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		02BF9988CC94A01E7CB6049694390020 /* NMBExceptionCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = 40FBD52025077E5788ADCE71EF040393 /* NMBExceptionCapture.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		02DF5BD2281BA10105A447F95FCF8CF3 /* BeLogical.swift in Sources */ = {isa = PBXBuildFile; fileRef = B011BCE1507648ECA7586CF7DABF6F4C /* BeLogical.swift */; };
+		0492354DA7EF0C9068F7B4E8F74001B0 /* FailureMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25961731CF4F7537A5ECD61A000A150C /* FailureMessage.swift */; };
+		0A6E71555F55082003A3DB2B03CA85D2 /* AsyncMatcherWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D42013D479CDC11E7882C7C0045B66B /* AsyncMatcherWrapper.swift */; };
+		0B7732297AC0B3E5B1F23E2C42B54D46 /* Pods-BugShaker_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = CD858CF00A986467FB2A648B9F3B5139 /* Pods-BugShaker_Tests-dummy.m */; };
+		0F49254A4C560DD4696936F6080756DC /* Nimble-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = BF4AE1E80CC4EA4F2E1FF17CA10A3D26 /* Nimble-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		12D288163471C02435CD488EEF5A28A9 /* BugShaker-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 431BA60F720B110A7D6027A6A02C4728 /* BugShaker-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1C6224A9927FACC89B0CD4B72FD87BCE /* Pods-BugShaker_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = E567FBFBC6D9424672F374B8B4BF14A7 /* Pods-BugShaker_Example-dummy.m */; };
+		1CDC4BCA23AF5BD9714205CB0D714CDF /* Quick-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 616BFD5BF73AEF373E5250D05560A338 /* Quick-dummy.m */; };
+		1E28F9362956B758C4C981D3C1129C90 /* BeGreaterThan.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3CD67A0263B5D926517C112081F48B2 /* BeGreaterThan.swift */; };
+		1FBFD99217008F83FF8DC98FF91890F8 /* QuickConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = AE670FBBCC7FBB0E81F05DA0C8EAAEE5 /* QuickConfiguration.m */; };
+		23373E5473E30B582040C7A2EC79FF12 /* QuickConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = F1D4A64A54F414359EC782444B27597B /* QuickConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		29BEB482AA2C54D51980695E4FDF9758 /* World.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8487245080A1AB0FFD48288B814AEA82 /* World.swift */; };
+		2D3B916F7168E9412EDB95BA203A5BB4 /* ThrowError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BC0728045ED4D4A2C12B52A561EEF7 /* ThrowError.swift */; };
+		33264C6A7A3536AD91EF42B3E8CC8220 /* BeGreaterThanOrEqualTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03BB6589A73F51F073DF050F55D7F41 /* BeGreaterThanOrEqualTo.swift */; };
+		33308ECBEA334D2FDA005CD6F2DA45E0 /* Callsite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C6D6E41BA9F922E7BBD3A24B7E5D00A /* Callsite.swift */; };
+		33514FEE6EA65605EFB6F1801834B692 /* AssertionDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B0C995C72A44C02A9369FA2BDB1F4FF /* AssertionDispatcher.swift */; };
+		33F681A53AC896D393DC00574B94764E /* Closures.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6E3634125A20B9BA58962919B08DDC /* Closures.swift */; };
+		3803D4385FCCF56A2DD978AD352A1A84 /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA259B09EFC48EBE7E448ABD767D00CD /* MessageUI.framework */; };
+		3A92AEE86034356AF8987F20EE1F82DF /* EndWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E8B6303CCFDEBF93094E92D50CAFF38 /* EndWith.swift */; };
+		3AEAC447B09E7AABC140654C8529BC94 /* MatcherFunc.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43EEEBE209F0CF242FBC231937E6922 /* MatcherFunc.swift */; };
+		46BB16FC37859B7B4BC1EC2353DDE1CA /* Pods-BugShaker_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 37F41358415CC95481B5A5B8796F6A4F /* Pods-BugShaker_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E87C6AE24AB15700A39FC24A2F1C93B /* BeLessThanOrEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E12C6F645E5DC0EDB23023A394F1CB1 /* BeLessThanOrEqual.swift */; };
+		5015D4063402CF2D227A195B900628A9 /* Pods-BugShaker_Tests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 506723EA44F0B474AF2C173A177C4956 /* Pods-BugShaker_Tests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		50329B4013D7CE9FAF00D03D540A3A2A /* ExampleGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2005F86F2C2D05CDE00BB78EF02D6D4 /* ExampleGroup.swift */; };
+		512DFAE728521F02AF225F0082195DCC /* Nimble.h in Headers */ = {isa = PBXBuildFile; fileRef = 784135A9193F0FE38182AF2C577B3A52 /* Nimble.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		58EBA2C1A43283FB2188AB1FB592D32B /* DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B9040AB08CA7AEB727960E284F746A4 /* DSL.swift */; };
+		6BB7E783D5E7001105BF26D5823338D7 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F0403F6C8D6E128C7B3673D26DAA6EBE /* XCTest.framework */; };
+		73695FA6A6CDFBB13C0CC73C2E5126C0 /* Nimble-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = C8E9634CF58B22F95DF5AA222CDAF9B8 /* Nimble-dummy.m */; };
+		74CEF11F353C3DDDF585BE8002E95067 /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7511682ED488897012E4EEC14429BF /* Filter.swift */; };
+		7680F08C43B965EC873D26E6AD854C9F /* BeIdenticalTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69A1AA2E4CDFA7B6FD9B4F253CAF481F /* BeIdenticalTo.swift */; };
+		77128C0365A98E3BAC038A915B38791C /* BeAKindOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B53DF3C5B85F993313E9FA09386C167 /* BeAKindOf.swift */; };
+		7A6E2730A25A55D8DFA74D3D7CB005EF /* BeAnInstanceOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13064CC241598F189B1341470994F9D9 /* BeAnInstanceOf.swift */; };
+		7BFD25B1BB1116D8AC47E2C3874C5B76 /* ObjCMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B922FF75D982F502B345AE30399F97 /* ObjCMatcher.swift */; };
+		7DA9FF8513AA48310B15A0744A541818 /* SourceLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4930275AC98E3FD0F3BC81A7D08B8591 /* SourceLocation.swift */; };
+		7E633EEF58ABC3C6597F724B505DBF7E /* DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33DD2CC5441C4540A072B29E4A257A9D /* DSL.swift */; };
+		82DE994ADB353F0F25516F55FD1E82FE /* World.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C0EAA5BA062125C64E6A819695F87C6 /* World.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		831D33A4C5C5BBC1EC158D9A236C61D7 /* NimbleXCTestHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5596CB4CEA7B7B71461C9ECE75263656 /* NimbleXCTestHandler.swift */; };
+		84F3A4106092139941339E0EBA671BE3 /* QCKDSL.h in Headers */ = {isa = PBXBuildFile; fileRef = E41A31E4949F1319040B8D2BBBF2B5D6 /* QCKDSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		879642BABEF0C9B9DC71BD6531B8FBFB /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BF695047E0AAFB3CA54EC10F0E97FD3 /* Configuration.swift */; };
+		8D0BF52FF564A170A3D1DE28C27B233E /* Poll.swift in Sources */ = {isa = PBXBuildFile; fileRef = F689A549CFB432AE0684F3EA3BA8D2FF /* Poll.swift */; };
+		8E82510F06423ABFD0739A508F6E3749 /* ExampleHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F8C281E400A6FABAD082CEA7263B2A /* ExampleHooks.swift */; };
+		9187EEC2982DB82AD8D3A7001AA647D6 /* NMBExceptionCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = F5F4CE0DE16848CBDA8A93366A52BEF7 /* NMBExceptionCapture.m */; };
+		9341B96D63EF6C54A1F906A1BBAEAF46 /* DSL.h in Headers */ = {isa = PBXBuildFile; fileRef = DA695A07DF17BA243064E57D889E1CBB /* DSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9646787942A85613FE77F45794E9B5CD /* BeginWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58CD57ED9D79412A49A037E8EAA4AF42 /* BeginWith.swift */; };
+		9891607FBE79C98611153F0C6DE3B44D /* ExampleMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38715BF4570032AE706B97AB11365E48 /* ExampleMetadata.swift */; };
+		9B9AF64B33F5A21C28D35DFDE37A4ABB /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 737CAA526F71894F2837578BF4092414 /* UIKit.framework */; };
+		9E7786C034F0E0A6B5F0A0E6BE7D7E4A /* BeEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FE24AE8654BDA8234080C23F6335E26 /* BeEmpty.swift */; };
+		A818323A89D5AA917ACF9ECC52640851 /* BugShaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 101EBA8F7261F3819A438AE40440E7F6 /* BugShaker.swift */; };
+		AA852E5024A0384695F373963AA9F6D7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B42A60DBB0178E9516A7AFDF81A55691 /* Foundation.framework */; };
+		ABBB0A2266C374D746BD39F6010DFCD4 /* NSString+QCKSelectorName.h in Headers */ = {isa = PBXBuildFile; fileRef = 64F492985EB6550A418DD3DB1BCDE146 /* NSString+QCKSelectorName.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		B0A26F58BA3E6222E50AE5AC883B8EAF /* DSL.m in Sources */ = {isa = PBXBuildFile; fileRef = D17DFC0D37F8449B1B2A2D117D1179A2 /* DSL.m */; };
+		B35233832E02DA15E2FC89266CEC4985 /* Example.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA1EFFE836005E11B9D420692E9E50C /* Example.swift */; };
+		B353D3C9178359229BED80422D2BF642 /* Quick.h in Headers */ = {isa = PBXBuildFile; fileRef = D4E0D7E2D11371A45CB3D1221E7B4EC2 /* Quick.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B41E8E775408ACE233F29CE93388B270 /* Contain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6727AA774C6723AFCA6CFCEF099071C7 /* Contain.swift */; };
+		B905718B2501DDA22F2AE73CB6E76E6B /* BeCloseTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29A378AC6A7BCB5D43F7586353A7610A /* BeCloseTo.swift */; };
+		BB4F35062294C1A461DA3CEF6306A1DB /* HaveCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54BC3268759E7DB38A0E192F06A1BD06 /* HaveCount.swift */; };
+		BC7FE855AE1A164926607E2BF394BB47 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B42A60DBB0178E9516A7AFDF81A55691 /* Foundation.framework */; };
+		BCB53F24DCADF12601B8BA90AE3190AE /* BeLessThan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69578BBC16AAA12ED9630E2036580E94 /* BeLessThan.swift */; };
+		C150157922BAEB1F93635508FB59E618 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B42A60DBB0178E9516A7AFDF81A55691 /* Foundation.framework */; };
+		C1641E35E665261FB9B679A3724A04C1 /* QCKDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = 2543809E4D3D9755B94735346ACDFF03 /* QCKDSL.m */; };
+		C26B0EC317FACDEB4657378800EE4343 /* NSString+QCKSelectorName.m in Sources */ = {isa = PBXBuildFile; fileRef = 20ABC5A3D02301EC1EC014B6ABEFA42A /* NSString+QCKSelectorName.m */; };
+		C56A9CD86FA12122057D810711F00733 /* QuickSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = 8880B82EFD81A0D6EE2BBD27A39D61BA /* QuickSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C63AB521EA514A811A167E507C0CF9AD /* Expression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 227AD60FAC82B3DEDDBB09BAEE052647 /* Expression.swift */; };
+		C9AC658F3FCB67B50E96313C2687B33D /* MatcherProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D0DF7E7A59098355B7877A39D254B6 /* MatcherProtocols.swift */; };
+		CAAED5FB81DB035A9EC080917C783FA6 /* AdapterProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECB4882E47E7537D32F4C677DF4F0B43 /* AdapterProtocols.swift */; };
+		CADB483A22FEF43C72C3E48AB84D4359 /* SuiteHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64F0BEE5B67844F0E333920C2CB3416C /* SuiteHooks.swift */; };
+		CB5214B20039D8A85922460A47C0BE53 /* Quick-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = FC9D0077C69A720B9DD2BB12344FD893 /* Quick-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CD9D31B6063C50689EAC2A0745C282DC /* ObjCExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7FE6BD80E2769820B83F2550DAC4AAF /* ObjCExpectation.swift */; };
+		D0E3192D662A776662F2C611F5229B1F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B42A60DBB0178E9516A7AFDF81A55691 /* Foundation.framework */; };
+		D429691F39B4C30A8993360FB8A3E334 /* AllPass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F2CCEF958AF4E4C4F073031905F2CE2 /* AllPass.swift */; };
+		D7B45D4600C6166C124C0A926EE65284 /* Functional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28E302676FFF0A4192E3ECFB4B1FDCF6 /* Functional.swift */; };
+		DEE170DD3064F7343884A4016546B762 /* DSL+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDA388FEA33C5B8824432D9681B318F3 /* DSL+Wait.swift */; };
+		DFDE50EEE54BEDB0BAF268B43E454D35 /* BugShaker-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 788785CF536F9C3198B986AC737EF3A8 /* BugShaker-dummy.m */; };
+		E2FBD93D72DF01427486D1A6853FC689 /* Expectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3116FC3DA077740D1C5702FA4C187A2 /* Expectation.swift */; };
+		E36C5201AE7F1CBB25F9D2E7CBFC3C20 /* Match.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0843BD7412E439120C081E8D9FE0F80 /* Match.swift */; };
+		E434C3728CD7C77F2B71425EBA3EAC1D /* World+DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DDA3CDE7515A11BE56C6C2FE5FB65D8 /* World+DSL.swift */; };
+		E6E7B15FAD6C56681511813DB2666478 /* AssertionRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B84D274316F8C6F9695294FB40D7596F /* AssertionRecorder.swift */; };
+		E770263333F9B1D2153E1D8C10AC9C20 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B42A60DBB0178E9516A7AFDF81A55691 /* Foundation.framework */; };
+		F10FD3129985704FA1610F84FB98EDF5 /* Stringers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E31CE50F8B4B99D3C229D2438892ED5B /* Stringers.swift */; };
+		F198E8ED3D32CD5EE31A8118E3F06B89 /* QuickSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 62241019A9DFE31F82A2CDF8690A163C /* QuickSpec.m */; };
+		F1D4A8A1FC68EFA7F45945908D70A352 /* BeNil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02297D692E5CA1B1C21CCCDA1853BA44 /* BeNil.swift */; };
+		FB1347627E64CA7E98C19DC985E13D95 /* Equal.swift in Sources */ = {isa = PBXBuildFile; fileRef = D75276E4A134A22E123F4C40E529080C /* Equal.swift */; };
+		FC92852C83D2A4830AD3AB94100D6CAC /* World+DSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 94A039912FDC46FCB2AF6DCEEB91ADB4 /* World+DSL.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		FFC311AC1E19A23E0EB7B1B3A7A5A744 /* RaisesException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88457B3A5C81E0F34AC48AC05B8040D6 /* RaisesException.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		1411D8286BD803903B6711E68F112A69 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7828ADC5769EB4DAF892E21623A8E882;
+			remoteInfo = BugShaker;
+		};
+		3672A1B8EA5250BE713E07097B5B391F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F81C00BA24D52450ACAC654BA45930A3;
+			remoteInfo = Quick;
+		};
+		88F42374D5D55E337F87C6A653F04F28 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7828ADC5769EB4DAF892E21623A8E882;
+			remoteInfo = BugShaker;
+		};
+		A106278B01533BFA91C895ACBF72DC74 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C5DB5104FED3C10F78978AFC810982B9;
+			remoteInfo = Nimble;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		01F8C281E400A6FABAD082CEA7263B2A /* ExampleHooks.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleHooks.swift; path = Quick/Hooks/ExampleHooks.swift; sourceTree = "<group>"; };
+		021C4E135FFC34B4A74FD0560A640549 /* Quick.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = Quick.modulemap; sourceTree = "<group>"; };
+		02297D692E5CA1B1C21CCCDA1853BA44 /* BeNil.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeNil.swift; path = Nimble/Matchers/BeNil.swift; sourceTree = "<group>"; };
+		07E52E548D408C38A2FCE68370FE599F /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		09EE78164DFDEBCDC53DF7F8B2371A59 /* Pods-BugShaker_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-BugShaker_Example.release.xcconfig"; sourceTree = "<group>"; };
+		0B0C995C72A44C02A9369FA2BDB1F4FF /* AssertionDispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AssertionDispatcher.swift; path = Nimble/Adapters/AssertionDispatcher.swift; sourceTree = "<group>"; };
+		0B53DF3C5B85F993313E9FA09386C167 /* BeAKindOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeAKindOf.swift; path = Nimble/Matchers/BeAKindOf.swift; sourceTree = "<group>"; };
+		101EBA8F7261F3819A438AE40440E7F6 /* BugShaker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BugShaker.swift; sourceTree = "<group>"; };
+		13064CC241598F189B1341470994F9D9 /* BeAnInstanceOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeAnInstanceOf.swift; path = Nimble/Matchers/BeAnInstanceOf.swift; sourceTree = "<group>"; };
+		1D42013D479CDC11E7882C7C0045B66B /* AsyncMatcherWrapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AsyncMatcherWrapper.swift; path = Nimble/Wrappers/AsyncMatcherWrapper.swift; sourceTree = "<group>"; };
+		1E8B6303CCFDEBF93094E92D50CAFF38 /* EndWith.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EndWith.swift; path = Nimble/Matchers/EndWith.swift; sourceTree = "<group>"; };
+		20ABC5A3D02301EC1EC014B6ABEFA42A /* NSString+QCKSelectorName.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSString+QCKSelectorName.m"; path = "Quick/NSString+QCKSelectorName.m"; sourceTree = "<group>"; };
+		227AD60FAC82B3DEDDBB09BAEE052647 /* Expression.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Expression.swift; path = Nimble/Expression.swift; sourceTree = "<group>"; };
+		2543809E4D3D9755B94735346ACDFF03 /* QCKDSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QCKDSL.m; path = Quick/DSL/QCKDSL.m; sourceTree = "<group>"; };
+		25961731CF4F7537A5ECD61A000A150C /* FailureMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FailureMessage.swift; path = Nimble/FailureMessage.swift; sourceTree = "<group>"; };
+		27495737E78922CA9371459D23A8E2B2 /* BugShaker.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = BugShaker.modulemap; sourceTree = "<group>"; };
+		28CBE0D19FC6E65EFAA29981A9422B23 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		28D0DF7E7A59098355B7877A39D254B6 /* MatcherProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MatcherProtocols.swift; path = Nimble/Matchers/MatcherProtocols.swift; sourceTree = "<group>"; };
+		28E302676FFF0A4192E3ECFB4B1FDCF6 /* Functional.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Functional.swift; path = Nimble/Utils/Functional.swift; sourceTree = "<group>"; };
+		29A378AC6A7BCB5D43F7586353A7610A /* BeCloseTo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeCloseTo.swift; path = Nimble/Matchers/BeCloseTo.swift; sourceTree = "<group>"; };
+		2B9040AB08CA7AEB727960E284F746A4 /* DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSL.swift; path = Nimble/DSL.swift; sourceTree = "<group>"; };
+		2FE24AE8654BDA8234080C23F6335E26 /* BeEmpty.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeEmpty.swift; path = Nimble/Matchers/BeEmpty.swift; sourceTree = "<group>"; };
+		33DD2CC5441C4540A072B29E4A257A9D /* DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSL.swift; path = Quick/DSL/DSL.swift; sourceTree = "<group>"; };
+		37F41358415CC95481B5A5B8796F6A4F /* Pods-BugShaker_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-BugShaker_Example-umbrella.h"; sourceTree = "<group>"; };
+		38715BF4570032AE706B97AB11365E48 /* ExampleMetadata.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleMetadata.swift; path = Quick/ExampleMetadata.swift; sourceTree = "<group>"; };
+		3DCC847CEB6D18B6175CDC70D984C1CB /* Quick.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3F1975D001BFB447009180BAF8C14ADB /* Quick-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Quick-prefix.pch"; sourceTree = "<group>"; };
+		40FBD52025077E5788ADCE71EF040393 /* NMBExceptionCapture.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NMBExceptionCapture.h; path = Nimble/objc/NMBExceptionCapture.h; sourceTree = "<group>"; };
+		431BA60F720B110A7D6027A6A02C4728 /* BugShaker-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "BugShaker-umbrella.h"; sourceTree = "<group>"; };
+		4930275AC98E3FD0F3BC81A7D08B8591 /* SourceLocation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SourceLocation.swift; path = Nimble/Utils/SourceLocation.swift; sourceTree = "<group>"; };
+		49D2C10033012388A1C76F8F0008CCDA /* Pods-BugShaker_Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-BugShaker_Tests-resources.sh"; sourceTree = "<group>"; };
+		4C0EAA5BA062125C64E6A819695F87C6 /* World.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = World.h; path = Quick/World.h; sourceTree = "<group>"; };
+		4C6D6E41BA9F922E7BBD3A24B7E5D00A /* Callsite.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Callsite.swift; path = Quick/Callsite.swift; sourceTree = "<group>"; };
+		4F2CCEF958AF4E4C4F073031905F2CE2 /* AllPass.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AllPass.swift; path = Nimble/Matchers/AllPass.swift; sourceTree = "<group>"; };
+		5000B8AA11C849BE381E87C8DE8CC906 /* Pods-BugShaker_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-BugShaker_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
+		506723EA44F0B474AF2C173A177C4956 /* Pods-BugShaker_Tests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-BugShaker_Tests-umbrella.h"; sourceTree = "<group>"; };
+		54BC3268759E7DB38A0E192F06A1BD06 /* HaveCount.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HaveCount.swift; path = Nimble/Matchers/HaveCount.swift; sourceTree = "<group>"; };
+		5596CB4CEA7B7B71461C9ECE75263656 /* NimbleXCTestHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NimbleXCTestHandler.swift; path = Nimble/Adapters/NimbleXCTestHandler.swift; sourceTree = "<group>"; };
+		58CD57ED9D79412A49A037E8EAA4AF42 /* BeginWith.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeginWith.swift; path = Nimble/Matchers/BeginWith.swift; sourceTree = "<group>"; };
+		5BF695047E0AAFB3CA54EC10F0E97FD3 /* Configuration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Configuration.swift; path = Quick/Configuration/Configuration.swift; sourceTree = "<group>"; };
+		5D6A2E71DBC9D0DE17402BCFCFEEBDB2 /* Nimble-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-prefix.pch"; sourceTree = "<group>"; };
+		616BFD5BF73AEF373E5250D05560A338 /* Quick-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Quick-dummy.m"; sourceTree = "<group>"; };
+		62241019A9DFE31F82A2CDF8690A163C /* QuickSpec.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickSpec.m; path = Quick/QuickSpec.m; sourceTree = "<group>"; };
+		64F0BEE5B67844F0E333920C2CB3416C /* SuiteHooks.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SuiteHooks.swift; path = Quick/Hooks/SuiteHooks.swift; sourceTree = "<group>"; };
+		64F492985EB6550A418DD3DB1BCDE146 /* NSString+QCKSelectorName.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSString+QCKSelectorName.h"; path = "Quick/NSString+QCKSelectorName.h"; sourceTree = "<group>"; };
+		6727AA774C6723AFCA6CFCEF099071C7 /* Contain.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Contain.swift; path = Nimble/Matchers/Contain.swift; sourceTree = "<group>"; };
+		69578BBC16AAA12ED9630E2036580E94 /* BeLessThan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLessThan.swift; path = Nimble/Matchers/BeLessThan.swift; sourceTree = "<group>"; };
+		69A1AA2E4CDFA7B6FD9B4F253CAF481F /* BeIdenticalTo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeIdenticalTo.swift; path = Nimble/Matchers/BeIdenticalTo.swift; sourceTree = "<group>"; };
+		6DDA3CDE7515A11BE56C6C2FE5FB65D8 /* World+DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "World+DSL.swift"; path = "Quick/DSL/World+DSL.swift"; sourceTree = "<group>"; };
+		721A738F53D076A6B08340B7D31CB8B4 /* Pods_BugShaker_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BugShaker_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		737CAA526F71894F2837578BF4092414 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
+		73B922FF75D982F502B345AE30399F97 /* ObjCMatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ObjCMatcher.swift; path = Nimble/Wrappers/ObjCMatcher.swift; sourceTree = "<group>"; };
+		7614695BDF651115141E0C313741C3B7 /* BugShaker.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = BugShaker.xcconfig; sourceTree = "<group>"; };
+		76652D2390F305CF2E223182EBCCCBEA /* Pods-BugShaker_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-BugShaker_Example-acknowledgements.plist"; sourceTree = "<group>"; };
+		7801642CF0C19CFAF3F416DCA9205330 /* Pods-BugShaker_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-BugShaker_Example.modulemap"; sourceTree = "<group>"; };
+		784135A9193F0FE38182AF2C577B3A52 /* Nimble.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Nimble.h; path = Nimble/Nimble.h; sourceTree = "<group>"; };
+		788785CF536F9C3198B986AC737EF3A8 /* BugShaker-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "BugShaker-dummy.m"; sourceTree = "<group>"; };
+		7C07CB259CB51CAA2B1B59537C0A7C2C /* Quick.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Quick.xcconfig; sourceTree = "<group>"; };
+		7F2BA4A2F087231E6FDB1A600EDA2781 /* Nimble.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7F8C629893CE8C61862558306B087F8B /* BugShaker-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "BugShaker-prefix.pch"; sourceTree = "<group>"; };
+		8487245080A1AB0FFD48288B814AEA82 /* World.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = World.swift; path = Quick/World.swift; sourceTree = "<group>"; };
+		88457B3A5C81E0F34AC48AC05B8040D6 /* RaisesException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RaisesException.swift; path = Nimble/Matchers/RaisesException.swift; sourceTree = "<group>"; };
+		8880B82EFD81A0D6EE2BBD27A39D61BA /* QuickSpec.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickSpec.h; path = Quick/QuickSpec.h; sourceTree = "<group>"; };
+		8D68E93BCE9FBAB79125DAA0CB530EA2 /* BugShaker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BugShaker.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8E12C6F645E5DC0EDB23023A394F1CB1 /* BeLessThanOrEqual.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLessThanOrEqual.swift; path = Nimble/Matchers/BeLessThanOrEqual.swift; sourceTree = "<group>"; };
+		94A039912FDC46FCB2AF6DCEEB91ADB4 /* World+DSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "World+DSL.h"; path = "Quick/DSL/World+DSL.h"; sourceTree = "<group>"; };
+		A68861981CBE3D023DD41160825ABE3E /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AE670FBBCC7FBB0E81F05DA0C8EAAEE5 /* QuickConfiguration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickConfiguration.m; path = Quick/Configuration/QuickConfiguration.m; sourceTree = "<group>"; };
+		AE6E3634125A20B9BA58962919B08DDC /* Closures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Closures.swift; path = Quick/Hooks/Closures.swift; sourceTree = "<group>"; };
+		B011BCE1507648ECA7586CF7DABF6F4C /* BeLogical.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLogical.swift; path = Nimble/Matchers/BeLogical.swift; sourceTree = "<group>"; };
+		B2005F86F2C2D05CDE00BB78EF02D6D4 /* ExampleGroup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleGroup.swift; path = Quick/ExampleGroup.swift; sourceTree = "<group>"; };
+		B3116FC3DA077740D1C5702FA4C187A2 /* Expectation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Expectation.swift; path = Nimble/Expectation.swift; sourceTree = "<group>"; };
+		B42A60DBB0178E9516A7AFDF81A55691 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		B68A276C05A93CFCC331A055BCA33167 /* Nimble.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Nimble.xcconfig; sourceTree = "<group>"; };
+		B84D274316F8C6F9695294FB40D7596F /* AssertionRecorder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AssertionRecorder.swift; path = Nimble/Adapters/AssertionRecorder.swift; sourceTree = "<group>"; };
+		BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		BEA1EFFE836005E11B9D420692E9E50C /* Example.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Example.swift; path = Quick/Example.swift; sourceTree = "<group>"; };
+		BF4AE1E80CC4EA4F2E1FF17CA10A3D26 /* Nimble-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-umbrella.h"; sourceTree = "<group>"; };
+		C03BB6589A73F51F073DF050F55D7F41 /* BeGreaterThanOrEqualTo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeGreaterThanOrEqualTo.swift; path = Nimble/Matchers/BeGreaterThanOrEqualTo.swift; sourceTree = "<group>"; };
+		C0A6BCB61FCEBCC4D70F2E1741D8548A /* Pods-BugShaker_Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-BugShaker_Tests.modulemap"; sourceTree = "<group>"; };
+		C8E9634CF58B22F95DF5AA222CDAF9B8 /* Nimble-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Nimble-dummy.m"; sourceTree = "<group>"; };
+		CC7BCA37977175879531162CA00513D5 /* Pods-BugShaker_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-BugShaker_Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		CD6892139A4E44DF95C89A6BE52900CE /* Nimble.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = Nimble.modulemap; sourceTree = "<group>"; };
+		CD858CF00A986467FB2A648B9F3B5139 /* Pods-BugShaker_Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-BugShaker_Tests-dummy.m"; sourceTree = "<group>"; };
+		D083CBC5AA658B33B925D63E6EEC63AA /* Pods-BugShaker_Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-BugShaker_Tests-frameworks.sh"; sourceTree = "<group>"; };
+		D0843BD7412E439120C081E8D9FE0F80 /* Match.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Match.swift; path = Nimble/Matchers/Match.swift; sourceTree = "<group>"; };
+		D157E1347DBD2B7267EF971FAEDEBA44 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D17DFC0D37F8449B1B2A2D117D1179A2 /* DSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSL.m; path = Nimble/objc/DSL.m; sourceTree = "<group>"; };
+		D4E0D7E2D11371A45CB3D1221E7B4EC2 /* Quick.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Quick.h; path = Quick/Quick.h; sourceTree = "<group>"; };
+		D69D0C3C958808F1C22D30391D7E5661 /* Pods-BugShaker_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-BugShaker_Example.debug.xcconfig"; sourceTree = "<group>"; };
+		D75276E4A134A22E123F4C40E529080C /* Equal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Equal.swift; path = Nimble/Matchers/Equal.swift; sourceTree = "<group>"; };
+		D7945824E2A14231CC0CF694E579121F /* Pods-BugShaker_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-BugShaker_Tests.release.xcconfig"; sourceTree = "<group>"; };
+		D89D1727D39A8F564BDAAC3CF49BAFE6 /* Pods-BugShaker_Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-BugShaker_Tests-acknowledgements.plist"; sourceTree = "<group>"; };
+		DA695A07DF17BA243064E57D889E1CBB /* DSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSL.h; path = Nimble/objc/DSL.h; sourceTree = "<group>"; };
+		DED9FC72620C43F0B30AB12284F8E804 /* Pods-BugShaker_Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-BugShaker_Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
+		E2BC0728045ED4D4A2C12B52A561EEF7 /* ThrowError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ThrowError.swift; path = Nimble/Matchers/ThrowError.swift; sourceTree = "<group>"; };
+		E31CE50F8B4B99D3C229D2438892ED5B /* Stringers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Stringers.swift; path = Nimble/Utils/Stringers.swift; sourceTree = "<group>"; };
+		E3CD67A0263B5D926517C112081F48B2 /* BeGreaterThan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeGreaterThan.swift; path = Nimble/Matchers/BeGreaterThan.swift; sourceTree = "<group>"; };
+		E41A31E4949F1319040B8D2BBBF2B5D6 /* QCKDSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QCKDSL.h; path = Quick/DSL/QCKDSL.h; sourceTree = "<group>"; };
+		E43EEEBE209F0CF242FBC231937E6922 /* MatcherFunc.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MatcherFunc.swift; path = Nimble/Wrappers/MatcherFunc.swift; sourceTree = "<group>"; };
+		E4CCB617FFA4C79D28D608088726AEEF /* Pods_BugShaker_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BugShaker_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E567FBFBC6D9424672F374B8B4BF14A7 /* Pods-BugShaker_Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-BugShaker_Example-dummy.m"; sourceTree = "<group>"; };
+		ECA88DD27A7F402ACF519D26AAFD759F /* Pods-BugShaker_Example-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-BugShaker_Example-resources.sh"; sourceTree = "<group>"; };
+		ECB4882E47E7537D32F4C677DF4F0B43 /* AdapterProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AdapterProtocols.swift; path = Nimble/Adapters/AdapterProtocols.swift; sourceTree = "<group>"; };
+		F0403F6C8D6E128C7B3673D26DAA6EBE /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		F1D4A64A54F414359EC782444B27597B /* QuickConfiguration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickConfiguration.h; path = Quick/Configuration/QuickConfiguration.h; sourceTree = "<group>"; };
+		F5F4CE0DE16848CBDA8A93366A52BEF7 /* NMBExceptionCapture.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NMBExceptionCapture.m; path = Nimble/objc/NMBExceptionCapture.m; sourceTree = "<group>"; };
+		F689A549CFB432AE0684F3EA3BA8D2FF /* Poll.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Poll.swift; path = Nimble/Utils/Poll.swift; sourceTree = "<group>"; };
+		F7FE6BD80E2769820B83F2550DAC4AAF /* ObjCExpectation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ObjCExpectation.swift; path = Nimble/ObjCExpectation.swift; sourceTree = "<group>"; };
+		FA259B09EFC48EBE7E448ABD767D00CD /* MessageUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MessageUI.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/MessageUI.framework; sourceTree = DEVELOPER_DIR; };
+		FAC447CAC58531686F3DE45628EA4445 /* Pods-BugShaker_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-BugShaker_Example-frameworks.sh"; sourceTree = "<group>"; };
+		FC9D0077C69A720B9DD2BB12344FD893 /* Quick-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Quick-umbrella.h"; sourceTree = "<group>"; };
+		FD0AF5781847E82CEC8A2C6AEE2DBE57 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		FDA388FEA33C5B8824432D9681B318F3 /* DSL+Wait.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "DSL+Wait.swift"; path = "Nimble/DSL+Wait.swift"; sourceTree = "<group>"; };
+		FF7511682ED488897012E4EEC14429BF /* Filter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Filter.swift; path = Quick/Filter.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		06546430D00901668EB3AEC385B7F0A5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E770263333F9B1D2153E1D8C10AC9C20 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		665A09125D9AC70FB8C515F2E8194942 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BC7FE855AE1A164926607E2BF394BB47 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7FBD7B1537B634BB7C94BB4D4384BD63 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C150157922BAEB1F93635508FB59E618 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A4CF89438D41A9EAD74225DDD0D54883 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D0E3192D662A776662F2C611F5229B1F /* Foundation.framework in Frameworks */,
+				6BB7E783D5E7001105BF26D5823338D7 /* XCTest.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C5DACDD1CA6F86195FB77C5BD2A2493F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AA852E5024A0384695F373963AA9F6D7 /* Foundation.framework in Frameworks */,
+				3803D4385FCCF56A2DD978AD352A1A84 /* MessageUI.framework in Frameworks */,
+				9B9AF64B33F5A21C28D35DFDE37A4ABB /* UIKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		14B8B9B15ECBE87983FF987239AB2D7B /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				A2518B1C03B5E93AF12D21B3D3CC4F2C /* iOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		16F40755D50C39F84A302222E30E8DD2 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				28CBE0D19FC6E65EFAA29981A9422B23 /* Info.plist */,
+				021C4E135FFC34B4A74FD0560A640549 /* Quick.modulemap */,
+				7C07CB259CB51CAA2B1B59537C0A7C2C /* Quick.xcconfig */,
+				616BFD5BF73AEF373E5250D05560A338 /* Quick-dummy.m */,
+				3F1975D001BFB447009180BAF8C14ADB /* Quick-prefix.pch */,
+				FC9D0077C69A720B9DD2BB12344FD893 /* Quick-umbrella.h */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Quick";
+			sourceTree = "<group>";
+		};
+		246CF67F0102459FC633C690755C675C /* BugShaker */ = {
+			isa = PBXGroup;
+			children = (
+				AEFC01C9F874670F9CD68C2113904DE4 /* Pod */,
+				FC95E54F15872E97EFCEA0CCCBA99560 /* Support Files */,
+			);
+			name = BugShaker;
+			path = ../..;
+			sourceTree = "<group>";
+		};
+		36FD97F93AB8E4D454DAB2C2051EC699 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				FD0AF5781847E82CEC8A2C6AEE2DBE57 /* Info.plist */,
+				CD6892139A4E44DF95C89A6BE52900CE /* Nimble.modulemap */,
+				B68A276C05A93CFCC331A055BCA33167 /* Nimble.xcconfig */,
+				C8E9634CF58B22F95DF5AA222CDAF9B8 /* Nimble-dummy.m */,
+				5D6A2E71DBC9D0DE17402BCFCFEEBDB2 /* Nimble-prefix.pch */,
+				BF4AE1E80CC4EA4F2E1FF17CA10A3D26 /* Nimble-umbrella.h */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Nimble";
+			sourceTree = "<group>";
+		};
+		42B038D3D87FE45882BE89839C62B720 /* Targets Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				AB730BD9DBF3925A4B111DB5B4B0F702 /* Pods-BugShaker_Example */,
+				B0AF273664A6EF4E73EE8D542A337901 /* Pods-BugShaker_Tests */,
+			);
+			name = "Targets Support Files";
+			sourceTree = "<group>";
+		};
+		64E98FF7B6454214F8290BB0AC208D8F /* Quick */ = {
+			isa = PBXGroup;
+			children = (
+				4C6D6E41BA9F922E7BBD3A24B7E5D00A /* Callsite.swift */,
+				AE6E3634125A20B9BA58962919B08DDC /* Closures.swift */,
+				5BF695047E0AAFB3CA54EC10F0E97FD3 /* Configuration.swift */,
+				33DD2CC5441C4540A072B29E4A257A9D /* DSL.swift */,
+				BEA1EFFE836005E11B9D420692E9E50C /* Example.swift */,
+				B2005F86F2C2D05CDE00BB78EF02D6D4 /* ExampleGroup.swift */,
+				01F8C281E400A6FABAD082CEA7263B2A /* ExampleHooks.swift */,
+				38715BF4570032AE706B97AB11365E48 /* ExampleMetadata.swift */,
+				FF7511682ED488897012E4EEC14429BF /* Filter.swift */,
+				64F492985EB6550A418DD3DB1BCDE146 /* NSString+QCKSelectorName.h */,
+				20ABC5A3D02301EC1EC014B6ABEFA42A /* NSString+QCKSelectorName.m */,
+				E41A31E4949F1319040B8D2BBBF2B5D6 /* QCKDSL.h */,
+				2543809E4D3D9755B94735346ACDFF03 /* QCKDSL.m */,
+				D4E0D7E2D11371A45CB3D1221E7B4EC2 /* Quick.h */,
+				F1D4A64A54F414359EC782444B27597B /* QuickConfiguration.h */,
+				AE670FBBCC7FBB0E81F05DA0C8EAAEE5 /* QuickConfiguration.m */,
+				8880B82EFD81A0D6EE2BBD27A39D61BA /* QuickSpec.h */,
+				62241019A9DFE31F82A2CDF8690A163C /* QuickSpec.m */,
+				64F0BEE5B67844F0E333920C2CB3416C /* SuiteHooks.swift */,
+				4C0EAA5BA062125C64E6A819695F87C6 /* World.h */,
+				8487245080A1AB0FFD48288B814AEA82 /* World.swift */,
+				94A039912FDC46FCB2AF6DCEEB91ADB4 /* World+DSL.h */,
+				6DDA3CDE7515A11BE56C6C2FE5FB65D8 /* World+DSL.swift */,
+				16F40755D50C39F84A302222E30E8DD2 /* Support Files */,
+			);
+			path = Quick;
+			sourceTree = "<group>";
+		};
+		7DB346D0F39D3F0E887471402A8071AB = {
+			isa = PBXGroup;
+			children = (
+				BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */,
+				CA897E611394AD64844169F417A27FA1 /* Development Pods */,
+				14B8B9B15ECBE87983FF987239AB2D7B /* Frameworks */,
+				8F29E9621F2E4347FEA6F6D7F0748038 /* Pods */,
+				9A7617658D882C4B907F9229254CAF65 /* Products */,
+				42B038D3D87FE45882BE89839C62B720 /* Targets Support Files */,
+			);
+			sourceTree = "<group>";
+		};
+		8F29E9621F2E4347FEA6F6D7F0748038 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				D877BEEDC4F6494B4B10BC732B32A32B /* Nimble */,
+				64E98FF7B6454214F8290BB0AC208D8F /* Quick */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		9A7617658D882C4B907F9229254CAF65 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				8D68E93BCE9FBAB79125DAA0CB530EA2 /* BugShaker.framework */,
+				7F2BA4A2F087231E6FDB1A600EDA2781 /* Nimble.framework */,
+				721A738F53D076A6B08340B7D31CB8B4 /* Pods_BugShaker_Example.framework */,
+				E4CCB617FFA4C79D28D608088726AEEF /* Pods_BugShaker_Tests.framework */,
+				3DCC847CEB6D18B6175CDC70D984C1CB /* Quick.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		A2518B1C03B5E93AF12D21B3D3CC4F2C /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				B42A60DBB0178E9516A7AFDF81A55691 /* Foundation.framework */,
+				FA259B09EFC48EBE7E448ABD767D00CD /* MessageUI.framework */,
+				737CAA526F71894F2837578BF4092414 /* UIKit.framework */,
+				F0403F6C8D6E128C7B3673D26DAA6EBE /* XCTest.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		AB730BD9DBF3925A4B111DB5B4B0F702 /* Pods-BugShaker_Example */ = {
+			isa = PBXGroup;
+			children = (
+				A68861981CBE3D023DD41160825ABE3E /* Info.plist */,
+				7801642CF0C19CFAF3F416DCA9205330 /* Pods-BugShaker_Example.modulemap */,
+				5000B8AA11C849BE381E87C8DE8CC906 /* Pods-BugShaker_Example-acknowledgements.markdown */,
+				76652D2390F305CF2E223182EBCCCBEA /* Pods-BugShaker_Example-acknowledgements.plist */,
+				E567FBFBC6D9424672F374B8B4BF14A7 /* Pods-BugShaker_Example-dummy.m */,
+				FAC447CAC58531686F3DE45628EA4445 /* Pods-BugShaker_Example-frameworks.sh */,
+				ECA88DD27A7F402ACF519D26AAFD759F /* Pods-BugShaker_Example-resources.sh */,
+				37F41358415CC95481B5A5B8796F6A4F /* Pods-BugShaker_Example-umbrella.h */,
+				D69D0C3C958808F1C22D30391D7E5661 /* Pods-BugShaker_Example.debug.xcconfig */,
+				09EE78164DFDEBCDC53DF7F8B2371A59 /* Pods-BugShaker_Example.release.xcconfig */,
+			);
+			name = "Pods-BugShaker_Example";
+			path = "Target Support Files/Pods-BugShaker_Example";
+			sourceTree = "<group>";
+		};
+		AEFC01C9F874670F9CD68C2113904DE4 /* Pod */ = {
+			isa = PBXGroup;
+			children = (
+				E5714D5AE778B7E04C7207D6A6CB50B9 /* Classes */,
+			);
+			path = Pod;
+			sourceTree = "<group>";
+		};
+		B0AF273664A6EF4E73EE8D542A337901 /* Pods-BugShaker_Tests */ = {
+			isa = PBXGroup;
+			children = (
+				07E52E548D408C38A2FCE68370FE599F /* Info.plist */,
+				C0A6BCB61FCEBCC4D70F2E1741D8548A /* Pods-BugShaker_Tests.modulemap */,
+				DED9FC72620C43F0B30AB12284F8E804 /* Pods-BugShaker_Tests-acknowledgements.markdown */,
+				D89D1727D39A8F564BDAAC3CF49BAFE6 /* Pods-BugShaker_Tests-acknowledgements.plist */,
+				CD858CF00A986467FB2A648B9F3B5139 /* Pods-BugShaker_Tests-dummy.m */,
+				D083CBC5AA658B33B925D63E6EEC63AA /* Pods-BugShaker_Tests-frameworks.sh */,
+				49D2C10033012388A1C76F8F0008CCDA /* Pods-BugShaker_Tests-resources.sh */,
+				506723EA44F0B474AF2C173A177C4956 /* Pods-BugShaker_Tests-umbrella.h */,
+				CC7BCA37977175879531162CA00513D5 /* Pods-BugShaker_Tests.debug.xcconfig */,
+				D7945824E2A14231CC0CF694E579121F /* Pods-BugShaker_Tests.release.xcconfig */,
+			);
+			name = "Pods-BugShaker_Tests";
+			path = "Target Support Files/Pods-BugShaker_Tests";
+			sourceTree = "<group>";
+		};
+		CA897E611394AD64844169F417A27FA1 /* Development Pods */ = {
+			isa = PBXGroup;
+			children = (
+				246CF67F0102459FC633C690755C675C /* BugShaker */,
+			);
+			name = "Development Pods";
+			sourceTree = "<group>";
+		};
+		D877BEEDC4F6494B4B10BC732B32A32B /* Nimble */ = {
+			isa = PBXGroup;
+			children = (
+				ECB4882E47E7537D32F4C677DF4F0B43 /* AdapterProtocols.swift */,
+				4F2CCEF958AF4E4C4F073031905F2CE2 /* AllPass.swift */,
+				0B0C995C72A44C02A9369FA2BDB1F4FF /* AssertionDispatcher.swift */,
+				B84D274316F8C6F9695294FB40D7596F /* AssertionRecorder.swift */,
+				1D42013D479CDC11E7882C7C0045B66B /* AsyncMatcherWrapper.swift */,
+				0B53DF3C5B85F993313E9FA09386C167 /* BeAKindOf.swift */,
+				13064CC241598F189B1341470994F9D9 /* BeAnInstanceOf.swift */,
+				29A378AC6A7BCB5D43F7586353A7610A /* BeCloseTo.swift */,
+				2FE24AE8654BDA8234080C23F6335E26 /* BeEmpty.swift */,
+				58CD57ED9D79412A49A037E8EAA4AF42 /* BeginWith.swift */,
+				E3CD67A0263B5D926517C112081F48B2 /* BeGreaterThan.swift */,
+				C03BB6589A73F51F073DF050F55D7F41 /* BeGreaterThanOrEqualTo.swift */,
+				69A1AA2E4CDFA7B6FD9B4F253CAF481F /* BeIdenticalTo.swift */,
+				69578BBC16AAA12ED9630E2036580E94 /* BeLessThan.swift */,
+				8E12C6F645E5DC0EDB23023A394F1CB1 /* BeLessThanOrEqual.swift */,
+				B011BCE1507648ECA7586CF7DABF6F4C /* BeLogical.swift */,
+				02297D692E5CA1B1C21CCCDA1853BA44 /* BeNil.swift */,
+				6727AA774C6723AFCA6CFCEF099071C7 /* Contain.swift */,
+				DA695A07DF17BA243064E57D889E1CBB /* DSL.h */,
+				D17DFC0D37F8449B1B2A2D117D1179A2 /* DSL.m */,
+				2B9040AB08CA7AEB727960E284F746A4 /* DSL.swift */,
+				FDA388FEA33C5B8824432D9681B318F3 /* DSL+Wait.swift */,
+				1E8B6303CCFDEBF93094E92D50CAFF38 /* EndWith.swift */,
+				D75276E4A134A22E123F4C40E529080C /* Equal.swift */,
+				B3116FC3DA077740D1C5702FA4C187A2 /* Expectation.swift */,
+				227AD60FAC82B3DEDDBB09BAEE052647 /* Expression.swift */,
+				25961731CF4F7537A5ECD61A000A150C /* FailureMessage.swift */,
+				28E302676FFF0A4192E3ECFB4B1FDCF6 /* Functional.swift */,
+				54BC3268759E7DB38A0E192F06A1BD06 /* HaveCount.swift */,
+				D0843BD7412E439120C081E8D9FE0F80 /* Match.swift */,
+				E43EEEBE209F0CF242FBC231937E6922 /* MatcherFunc.swift */,
+				28D0DF7E7A59098355B7877A39D254B6 /* MatcherProtocols.swift */,
+				784135A9193F0FE38182AF2C577B3A52 /* Nimble.h */,
+				5596CB4CEA7B7B71461C9ECE75263656 /* NimbleXCTestHandler.swift */,
+				40FBD52025077E5788ADCE71EF040393 /* NMBExceptionCapture.h */,
+				F5F4CE0DE16848CBDA8A93366A52BEF7 /* NMBExceptionCapture.m */,
+				F7FE6BD80E2769820B83F2550DAC4AAF /* ObjCExpectation.swift */,
+				73B922FF75D982F502B345AE30399F97 /* ObjCMatcher.swift */,
+				F689A549CFB432AE0684F3EA3BA8D2FF /* Poll.swift */,
+				88457B3A5C81E0F34AC48AC05B8040D6 /* RaisesException.swift */,
+				4930275AC98E3FD0F3BC81A7D08B8591 /* SourceLocation.swift */,
+				E31CE50F8B4B99D3C229D2438892ED5B /* Stringers.swift */,
+				E2BC0728045ED4D4A2C12B52A561EEF7 /* ThrowError.swift */,
+				36FD97F93AB8E4D454DAB2C2051EC699 /* Support Files */,
+			);
+			path = Nimble;
+			sourceTree = "<group>";
+		};
+		E5714D5AE778B7E04C7207D6A6CB50B9 /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				101EBA8F7261F3819A438AE40440E7F6 /* BugShaker.swift */,
+			);
+			path = Classes;
+			sourceTree = "<group>";
+		};
+		FC95E54F15872E97EFCEA0CCCBA99560 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				27495737E78922CA9371459D23A8E2B2 /* BugShaker.modulemap */,
+				7614695BDF651115141E0C313741C3B7 /* BugShaker.xcconfig */,
+				788785CF536F9C3198B986AC737EF3A8 /* BugShaker-dummy.m */,
+				7F8C629893CE8C61862558306B087F8B /* BugShaker-prefix.pch */,
+				431BA60F720B110A7D6027A6A02C4728 /* BugShaker-umbrella.h */,
+				D157E1347DBD2B7267EF971FAEDEBA44 /* Info.plist */,
+			);
+			name = "Support Files";
+			path = "Example/Pods/Target Support Files/BugShaker";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		1691877C6D2074D233F5E7A774F8CAC3 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				ABBB0A2266C374D746BD39F6010DFCD4 /* NSString+QCKSelectorName.h in Headers */,
+				84F3A4106092139941339E0EBA671BE3 /* QCKDSL.h in Headers */,
+				CB5214B20039D8A85922460A47C0BE53 /* Quick-umbrella.h in Headers */,
+				B353D3C9178359229BED80422D2BF642 /* Quick.h in Headers */,
+				23373E5473E30B582040C7A2EC79FF12 /* QuickConfiguration.h in Headers */,
+				C56A9CD86FA12122057D810711F00733 /* QuickSpec.h in Headers */,
+				FC92852C83D2A4830AD3AB94100D6CAC /* World+DSL.h in Headers */,
+				82DE994ADB353F0F25516F55FD1E82FE /* World.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2C3F2FC46ABA330204D01364F4E6FD56 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				12D288163471C02435CD488EEF5A28A9 /* BugShaker-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4E5EE64F5FC342227A41FF819F1742FA /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				46BB16FC37859B7B4BC1EC2353DDE1CA /* Pods-BugShaker_Example-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E1B69F5654D9D49337C6DE24185B3C33 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5015D4063402CF2D227A195B900628A9 /* Pods-BugShaker_Tests-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E558CFA5C045F339837B0B7645133081 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9341B96D63EF6C54A1F906A1BBAEAF46 /* DSL.h in Headers */,
+				0F49254A4C560DD4696936F6080756DC /* Nimble-umbrella.h in Headers */,
+				512DFAE728521F02AF225F0082195DCC /* Nimble.h in Headers */,
+				02BF9988CC94A01E7CB6049694390020 /* NMBExceptionCapture.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		2827B0B43D92361FDF052CC901660E5D /* Pods-BugShaker_Example */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = ECF81F30316910BA0C06DDC2B3337A12 /* Build configuration list for PBXNativeTarget "Pods-BugShaker_Example" */;
+			buildPhases = (
+				4C8339F2225BA0DF6480C35F46482ED5 /* Sources */,
+				665A09125D9AC70FB8C515F2E8194942 /* Frameworks */,
+				4E5EE64F5FC342227A41FF819F1742FA /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				8F85468A83D5AF5427A70CE9FCAB6D76 /* PBXTargetDependency */,
+			);
+			name = "Pods-BugShaker_Example";
+			productName = "Pods-BugShaker_Example";
+			productReference = 721A738F53D076A6B08340B7D31CB8B4 /* Pods_BugShaker_Example.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		6C2F4D7C30FC57DC6B91C6FBEF4028F1 /* Pods-BugShaker_Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 40E0D37BCD2C9C7D2ECB018A583D07F6 /* Build configuration list for PBXNativeTarget "Pods-BugShaker_Tests" */;
+			buildPhases = (
+				19EC1395DFD2F2DC04AE7BE7ED7C683E /* Sources */,
+				06546430D00901668EB3AEC385B7F0A5 /* Frameworks */,
+				E1B69F5654D9D49337C6DE24185B3C33 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				BCEC70149D2C83BB29AC58CF3E938D06 /* PBXTargetDependency */,
+				7CC2885285B278894D0F1249965C9A54 /* PBXTargetDependency */,
+				2544D1AF73C4E4FBD9E92BA07519E5C1 /* PBXTargetDependency */,
+			);
+			name = "Pods-BugShaker_Tests";
+			productName = "Pods-BugShaker_Tests";
+			productReference = E4CCB617FFA4C79D28D608088726AEEF /* Pods_BugShaker_Tests.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		7828ADC5769EB4DAF892E21623A8E882 /* BugShaker */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FD92E9C0CB2C715A52945C98D54DEC64 /* Build configuration list for PBXNativeTarget "BugShaker" */;
+			buildPhases = (
+				3B9F2A15FE34848999B48EF82F6EFBD5 /* Sources */,
+				C5DACDD1CA6F86195FB77C5BD2A2493F /* Frameworks */,
+				2C3F2FC46ABA330204D01364F4E6FD56 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = BugShaker;
+			productName = BugShaker;
+			productReference = 8D68E93BCE9FBAB79125DAA0CB530EA2 /* BugShaker.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		C5DB5104FED3C10F78978AFC810982B9 /* Nimble */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D4DCEA35595251EC6B9BDC29A571E7B2 /* Build configuration list for PBXNativeTarget "Nimble" */;
+			buildPhases = (
+				CC264E557A8A184C30ECCED31C74BB34 /* Sources */,
+				7FBD7B1537B634BB7C94BB4D4384BD63 /* Frameworks */,
+				E558CFA5C045F339837B0B7645133081 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Nimble;
+			productName = Nimble;
+			productReference = 7F2BA4A2F087231E6FDB1A600EDA2781 /* Nimble.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		F81C00BA24D52450ACAC654BA45930A3 /* Quick */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = ACE8C39E8FD2C0C4537CC1C977FBB1C7 /* Build configuration list for PBXNativeTarget "Quick" */;
+			buildPhases = (
+				68C27A65CCB6FE4316E3221836FE7EFA /* Sources */,
+				A4CF89438D41A9EAD74225DDD0D54883 /* Frameworks */,
+				1691877C6D2074D233F5E7A774F8CAC3 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Quick;
+			productName = Quick;
+			productReference = 3DCC847CEB6D18B6175CDC70D984C1CB /* Quick.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		D41D8CD98F00B204E9800998ECF8427E /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0700;
+			};
+			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 7DB346D0F39D3F0E887471402A8071AB;
+			productRefGroup = 9A7617658D882C4B907F9229254CAF65 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				7828ADC5769EB4DAF892E21623A8E882 /* BugShaker */,
+				C5DB5104FED3C10F78978AFC810982B9 /* Nimble */,
+				2827B0B43D92361FDF052CC901660E5D /* Pods-BugShaker_Example */,
+				6C2F4D7C30FC57DC6B91C6FBEF4028F1 /* Pods-BugShaker_Tests */,
+				F81C00BA24D52450ACAC654BA45930A3 /* Quick */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		19EC1395DFD2F2DC04AE7BE7ED7C683E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0B7732297AC0B3E5B1F23E2C42B54D46 /* Pods-BugShaker_Tests-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3B9F2A15FE34848999B48EF82F6EFBD5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DFDE50EEE54BEDB0BAF268B43E454D35 /* BugShaker-dummy.m in Sources */,
+				A818323A89D5AA917ACF9ECC52640851 /* BugShaker.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4C8339F2225BA0DF6480C35F46482ED5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1C6224A9927FACC89B0CD4B72FD87BCE /* Pods-BugShaker_Example-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		68C27A65CCB6FE4316E3221836FE7EFA /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				33308ECBEA334D2FDA005CD6F2DA45E0 /* Callsite.swift in Sources */,
+				33F681A53AC896D393DC00574B94764E /* Closures.swift in Sources */,
+				879642BABEF0C9B9DC71BD6531B8FBFB /* Configuration.swift in Sources */,
+				7E633EEF58ABC3C6597F724B505DBF7E /* DSL.swift in Sources */,
+				B35233832E02DA15E2FC89266CEC4985 /* Example.swift in Sources */,
+				50329B4013D7CE9FAF00D03D540A3A2A /* ExampleGroup.swift in Sources */,
+				8E82510F06423ABFD0739A508F6E3749 /* ExampleHooks.swift in Sources */,
+				9891607FBE79C98611153F0C6DE3B44D /* ExampleMetadata.swift in Sources */,
+				74CEF11F353C3DDDF585BE8002E95067 /* Filter.swift in Sources */,
+				C26B0EC317FACDEB4657378800EE4343 /* NSString+QCKSelectorName.m in Sources */,
+				C1641E35E665261FB9B679A3724A04C1 /* QCKDSL.m in Sources */,
+				1CDC4BCA23AF5BD9714205CB0D714CDF /* Quick-dummy.m in Sources */,
+				1FBFD99217008F83FF8DC98FF91890F8 /* QuickConfiguration.m in Sources */,
+				F198E8ED3D32CD5EE31A8118E3F06B89 /* QuickSpec.m in Sources */,
+				CADB483A22FEF43C72C3E48AB84D4359 /* SuiteHooks.swift in Sources */,
+				E434C3728CD7C77F2B71425EBA3EAC1D /* World+DSL.swift in Sources */,
+				29BEB482AA2C54D51980695E4FDF9758 /* World.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CC264E557A8A184C30ECCED31C74BB34 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CAAED5FB81DB035A9EC080917C783FA6 /* AdapterProtocols.swift in Sources */,
+				D429691F39B4C30A8993360FB8A3E334 /* AllPass.swift in Sources */,
+				33514FEE6EA65605EFB6F1801834B692 /* AssertionDispatcher.swift in Sources */,
+				E6E7B15FAD6C56681511813DB2666478 /* AssertionRecorder.swift in Sources */,
+				0A6E71555F55082003A3DB2B03CA85D2 /* AsyncMatcherWrapper.swift in Sources */,
+				77128C0365A98E3BAC038A915B38791C /* BeAKindOf.swift in Sources */,
+				7A6E2730A25A55D8DFA74D3D7CB005EF /* BeAnInstanceOf.swift in Sources */,
+				B905718B2501DDA22F2AE73CB6E76E6B /* BeCloseTo.swift in Sources */,
+				9E7786C034F0E0A6B5F0A0E6BE7D7E4A /* BeEmpty.swift in Sources */,
+				9646787942A85613FE77F45794E9B5CD /* BeginWith.swift in Sources */,
+				1E28F9362956B758C4C981D3C1129C90 /* BeGreaterThan.swift in Sources */,
+				33264C6A7A3536AD91EF42B3E8CC8220 /* BeGreaterThanOrEqualTo.swift in Sources */,
+				7680F08C43B965EC873D26E6AD854C9F /* BeIdenticalTo.swift in Sources */,
+				BCB53F24DCADF12601B8BA90AE3190AE /* BeLessThan.swift in Sources */,
+				4E87C6AE24AB15700A39FC24A2F1C93B /* BeLessThanOrEqual.swift in Sources */,
+				02DF5BD2281BA10105A447F95FCF8CF3 /* BeLogical.swift in Sources */,
+				F1D4A8A1FC68EFA7F45945908D70A352 /* BeNil.swift in Sources */,
+				B41E8E775408ACE233F29CE93388B270 /* Contain.swift in Sources */,
+				DEE170DD3064F7343884A4016546B762 /* DSL+Wait.swift in Sources */,
+				B0A26F58BA3E6222E50AE5AC883B8EAF /* DSL.m in Sources */,
+				58EBA2C1A43283FB2188AB1FB592D32B /* DSL.swift in Sources */,
+				3A92AEE86034356AF8987F20EE1F82DF /* EndWith.swift in Sources */,
+				FB1347627E64CA7E98C19DC985E13D95 /* Equal.swift in Sources */,
+				E2FBD93D72DF01427486D1A6853FC689 /* Expectation.swift in Sources */,
+				C63AB521EA514A811A167E507C0CF9AD /* Expression.swift in Sources */,
+				0492354DA7EF0C9068F7B4E8F74001B0 /* FailureMessage.swift in Sources */,
+				D7B45D4600C6166C124C0A926EE65284 /* Functional.swift in Sources */,
+				BB4F35062294C1A461DA3CEF6306A1DB /* HaveCount.swift in Sources */,
+				E36C5201AE7F1CBB25F9D2E7CBFC3C20 /* Match.swift in Sources */,
+				3AEAC447B09E7AABC140654C8529BC94 /* MatcherFunc.swift in Sources */,
+				C9AC658F3FCB67B50E96313C2687B33D /* MatcherProtocols.swift in Sources */,
+				73695FA6A6CDFBB13C0CC73C2E5126C0 /* Nimble-dummy.m in Sources */,
+				831D33A4C5C5BBC1EC158D9A236C61D7 /* NimbleXCTestHandler.swift in Sources */,
+				9187EEC2982DB82AD8D3A7001AA647D6 /* NMBExceptionCapture.m in Sources */,
+				CD9D31B6063C50689EAC2A0745C282DC /* ObjCExpectation.swift in Sources */,
+				7BFD25B1BB1116D8AC47E2C3874C5B76 /* ObjCMatcher.swift in Sources */,
+				8D0BF52FF564A170A3D1DE28C27B233E /* Poll.swift in Sources */,
+				FFC311AC1E19A23E0EB7B1B3A7A5A744 /* RaisesException.swift in Sources */,
+				7DA9FF8513AA48310B15A0744A541818 /* SourceLocation.swift in Sources */,
+				F10FD3129985704FA1610F84FB98EDF5 /* Stringers.swift in Sources */,
+				2D3B916F7168E9412EDB95BA203A5BB4 /* ThrowError.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		2544D1AF73C4E4FBD9E92BA07519E5C1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Quick;
+			target = F81C00BA24D52450ACAC654BA45930A3 /* Quick */;
+			targetProxy = 3672A1B8EA5250BE713E07097B5B391F /* PBXContainerItemProxy */;
+		};
+		7CC2885285B278894D0F1249965C9A54 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Nimble;
+			target = C5DB5104FED3C10F78978AFC810982B9 /* Nimble */;
+			targetProxy = A106278B01533BFA91C895ACBF72DC74 /* PBXContainerItemProxy */;
+		};
+		8F85468A83D5AF5427A70CE9FCAB6D76 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BugShaker;
+			target = 7828ADC5769EB4DAF892E21623A8E882 /* BugShaker */;
+			targetProxy = 88F42374D5D55E337F87C6A653F04F28 /* PBXContainerItemProxy */;
+		};
+		BCEC70149D2C83BB29AC58CF3E938D06 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BugShaker;
+			target = 7828ADC5769EB4DAF892E21623A8E882 /* BugShaker */;
+			targetProxy = 1411D8286BD803903B6711E68F112A69 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		00C8CD26B2C1F06431111A7FDB3DA608 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D69D0C3C958808F1C22D30391D7E5661 /* Pods-BugShaker_Example.debug.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				INFOPLIST_FILE = "Target Support Files/Pods-BugShaker_Example/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-BugShaker_Example/Pods-BugShaker_Example.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = Pods_BugShaker_Example;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		04EC5F18BDD3545787BB51C22D3CFF80 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7C07CB259CB51CAA2B1B59537C0A7C2C /* Quick.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Quick/Quick-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Quick/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Quick/Quick.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = Quick;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		10DE1947DAC0ED28F6C0A9F9BD75D546 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_PREPROCESSOR_DEFINITIONS = "RELEASE=1";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				STRIP_INSTALLED_PRODUCT = NO;
+				SYMROOT = "${SRCROOT}/../build";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		158D2F39048E564B3A3EC976B747517F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7614695BDF651115141E0C313741C3B7 /* BugShaker.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/BugShaker/BugShaker-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/BugShaker/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/BugShaker/BugShaker.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = BugShaker;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		3A931A7644CC926D3162E0BA9E4ACFA6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = B68A276C05A93CFCC331A055BCA33167 /* Nimble.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Nimble/Nimble-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Nimble/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Nimble/Nimble.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = Nimble;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		4EF564BEA62C557AE8F9B8C1693AA239 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = B68A276C05A93CFCC331A055BCA33167 /* Nimble.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Nimble/Nimble-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Nimble/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Nimble/Nimble.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = Nimble;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		552D02D5BA751AC2E8790D2811D496CA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				ONLY_ACTIVE_ARCH = YES;
+				STRIP_INSTALLED_PRODUCT = NO;
+				SYMROOT = "${SRCROOT}/../build";
+			};
+			name = Debug;
+		};
+		7DC4BC34F0D11E715306FA91EA83B983 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7C07CB259CB51CAA2B1B59537C0A7C2C /* Quick.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Quick/Quick-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Quick/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Quick/Quick.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = Quick;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		B02024C36A91A450264A65ACF1CB3BCB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CC7BCA37977175879531162CA00513D5 /* Pods-BugShaker_Tests.debug.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				INFOPLIST_FILE = "Target Support Files/Pods-BugShaker_Tests/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-BugShaker_Tests/Pods-BugShaker_Tests.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = Pods_BugShaker_Tests;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		E0AB8742F4AAA4B07D0A897E718FDF9E /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 09EE78164DFDEBCDC53DF7F8B2371A59 /* Pods-BugShaker_Example.release.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				INFOPLIST_FILE = "Target Support Files/Pods-BugShaker_Example/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-BugShaker_Example/Pods-BugShaker_Example.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = Pods_BugShaker_Example;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		E54D6111CDCAA92FC64F3C67A73EC820 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7614695BDF651115141E0C313741C3B7 /* BugShaker.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/BugShaker/BugShaker-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/BugShaker/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/BugShaker/BugShaker.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = BugShaker;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		FDC38713E03A1A02B4B3A97C097905EB /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D7945824E2A14231CC0CF694E579121F /* Pods-BugShaker_Tests.release.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				INFOPLIST_FILE = "Target Support Files/Pods-BugShaker_Tests/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-BugShaker_Tests/Pods-BugShaker_Tests.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = Pods_BugShaker_Tests;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				552D02D5BA751AC2E8790D2811D496CA /* Debug */,
+				10DE1947DAC0ED28F6C0A9F9BD75D546 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		40E0D37BCD2C9C7D2ECB018A583D07F6 /* Build configuration list for PBXNativeTarget "Pods-BugShaker_Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B02024C36A91A450264A65ACF1CB3BCB /* Debug */,
+				FDC38713E03A1A02B4B3A97C097905EB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		ACE8C39E8FD2C0C4537CC1C977FBB1C7 /* Build configuration list for PBXNativeTarget "Quick" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7DC4BC34F0D11E715306FA91EA83B983 /* Debug */,
+				04EC5F18BDD3545787BB51C22D3CFF80 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D4DCEA35595251EC6B9BDC29A571E7B2 /* Build configuration list for PBXNativeTarget "Nimble" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3A931A7644CC926D3162E0BA9E4ACFA6 /* Debug */,
+				4EF564BEA62C557AE8F9B8C1693AA239 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		ECF81F30316910BA0C06DDC2B3337A12 /* Build configuration list for PBXNativeTarget "Pods-BugShaker_Example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				00C8CD26B2C1F06431111A7FDB3DA608 /* Debug */,
+				E0AB8742F4AAA4B07D0A897E718FDF9E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FD92E9C0CB2C715A52945C98D54DEC64 /* Build configuration list for PBXNativeTarget "BugShaker" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				158D2F39048E564B3A3EC976B747517F /* Debug */,
+				E54D6111CDCAA92FC64F3C67A73EC820 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+}

--- a/_pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/_pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/_pods.xcodeproj/xcshareddata/xcschemes/BugShaker.xcscheme
+++ b/_pods.xcodeproj/xcshareddata/xcschemes/BugShaker.xcscheme
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0700"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForAnalyzing = "YES"
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES">
+            <BuildableReference
+               BuildableIdentifier = 'primary'
+               BlueprintIdentifier = '8FBDD59516B0413B3E49ECD6'
+               BlueprintName = 'BugShaker'
+               ReferencedContainer = 'container:Pods.xcodeproj'
+               BuildableName = 'BugShaker.framework'>
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      buildConfiguration = "Debug"
+      allowLocationSimulation = "YES">
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
There are cases that you don't want the feature to be enabled. 
Examples: some users use the app while running around, and get annoyed by the prompt popping up all the time. 
To make it possible for the app to enable and disable the shake to bug report feature, I added a delegate protocol. 
