### PR TITLE
Update screenshot logic to handle blurred views.

### DIFF
--- a/Sources/BugShaker.swift
+++ b/Sources/BugShaker.swift
@@ -83,18 +83,16 @@ extension UIViewController: MFMailComposeViewControllerDelegate {
      - returns: Screenshot image.
      */
     @objc func captureScreenshot() -> UIImage? {
-        guard let layer = UIApplication.shared.keyWindow?.layer else { return nil }
-        
-        defer {
-            UIGraphicsEndImageContext()
-        }
-        
-        UIGraphicsBeginImageContextWithOptions(layer.frame.size, false, UIScreen.main.scale)
-        
-        guard let context = UIGraphicsGetCurrentContext() else { return nil }
-        
-        layer.render(in: context)
-        
+        guard let window = UIApplication.shared.keyWindow else { return nil }
+
+        UIGraphicsBeginImageContextWithOptions(window.frame.size,
+                                               true,
+                                               window.screen.scale)
+
+        defer { UIGraphicsEndImageContext() }
+
+        window.drawHierarchy(in: window.bounds, afterScreenUpdates: false)
+
         return UIGraphicsGetImageFromCurrentImageContext()
     }
     


### PR DESCRIPTION
By using the `drawHierarchy(in:afterScreenUpdates:)` method of `UIWindow`, we can draw the entire view hierarchy of the app’s window, including the blurring caused by `UIVisualEffectView`s.

Fixes #28.

## Screenshots
Before:
![screenshot](https://user-images.githubusercontent.com/147458/43732211-f3d73d0e-997e-11e8-97e1-43de9008d6c2.jpeg)

After:
![screenshot-2](https://user-images.githubusercontent.com/147458/43732216-f786b088-997e-11e8-87fc-06249d1c79be.jpeg)