### PR TITLE
Present the BugShaker prompt as alert on iPad.

### DIFF
--- a/Sources/BugShaker.swift
+++ b/Sources/BugShaker.swift
@@ -59,19 +59,27 @@ extension UIViewController: MFMailComposeViewControllerDelegate {
     // MARK: - Alert
     
     @objc func presentReportPrompt(_ reportActionHandler: @escaping (UIAlertAction) -> Void) {
-        let actionSheet = UIAlertController(
+        let preferredStyle: UIAlertControllerStyle
+
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            preferredStyle = .alert
+        } else {
+            preferredStyle = .actionSheet
+        }
+
+        let alertController = UIAlertController(
             title: "Shake detected!",
             message: "Would you like to report a bug?",
-            preferredStyle: .actionSheet
+            preferredStyle: preferredStyle
         )
         
         let reportAction = UIAlertAction(title: "Report A Bug", style: .default, handler: reportActionHandler)
         let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
         
-        actionSheet.addAction(reportAction)
-        actionSheet.addAction(cancelAction)
+        alertController.addAction(reportAction)
+        alertController.addAction(cancelAction)
         
-        present(actionSheet, animated: true, completion: nil)
+        present(alertController, animated: true, completion: nil)
     }
     
     


### PR DESCRIPTION
This gets around a bug on iPad where presenting it as an action sheet crashes, since action sheets on iPad are presented using popovers, which require source rects to display. The fix instead creates them with the `.alert` style, which presents them as generic alerts.

Fixes #29.

## Screenshots
![img_0315](https://user-images.githubusercontent.com/147458/43732689-53c1e06a-9980-11e8-9a79-e552731181fd.png)
