### PR TITLE
Open mailComposeController Method to Modification

### DIFF
--- a/Sources/BugShaker.swift
+++ b/Sources/BugShaker.swift
@@ -134,7 +134,7 @@ extension UIViewController: MFMailComposeViewControllerDelegate {
     
     // MARK: - MFMailComposeViewControllerDelegate
     
-    public func mailComposeController(_ controller: MFMailComposeViewController,
+    open func mailComposeController(_ controller: MFMailComposeViewController,
             didFinishWith result: MFMailComposeResult, error: Error?) {
         if let error = error {
             print("BugShaker – Error: \(error)")


### PR DESCRIPTION
#### What does this PR do?
Allows other `UIViewController` subclasses to implement `mailComposeController(_ didFinishWithResult)`

#### Any context you'd like to provide?
This came about while attempting to integrate BugShaker into a project that already conformed to the `MFMailComposeViewControllerDelegate`. If another/better way to work around this comes about I'm happy to revisit!