### PR TITLE
Fixed TravisCI Bundler version issue.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ notifications:
     on_success: change
 before_install:
   - rvm use $RVM_RUBY_VERSION
+  - gem update --system
+  - gem install bundler
   - gem install cocoapods
   - pod repo update
   - pod install


### PR DESCRIPTION
"On January 3rd 2019 the Bundler team released Bundler 2.0 which dropped support for Ruby versions 2.2 and older, and added a new dependency on RubyGems 3.0.0. A subsequent release, 2.0.1, requires RubyGems 2.5.0.

Under many configurations, Travis CI installs the Ruby runtime on the fly. This means installing the latest Bundler at run time, which may cause problems due to the unsatisfied requirements."

see: https://docs.travis-ci.com/user/languages/ruby/#bundler-20