### PR TITLE
Pass motion event to next responder if not being handled

### DIFF
--- a/Sources/BugShaker.swift
+++ b/Sources/BugShaker.swift
@@ -47,7 +47,10 @@ extension UIViewController: MFMailComposeViewControllerDelegate {
     }
     
     override open func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
-        guard BugShaker.isEnabled && motion == .motionShake else { return }
+        guard BugShaker.isEnabled && motion == .motionShake else {
+            next?.motionEnded(motion, with: event)
+            return
+        }
         
         let cachedScreenshot = captureScreenshot()
         


### PR DESCRIPTION
This PR resolves #47.
When disabling the BugShaker the motion event is handled by doing nothing and cuts the responder chain. This PR changes this behavior by passing the motion event to the next responder (if any) if the UIViewController is not interested in handling it.